### PR TITLE
Swagger 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ repositories {
 
 dependencies {
 	compile 'org.modelmapper:modelmapper:2.3.0'
+	// swagger
+	compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+	compile("io.springfox:springfox-swagger2:2.9.2") { exclude module: 'swagger-annotations' exclude module: 'swagger-models' }
+	compile("io.swagger:swagger-annotations:1.5.21")
+	compile("io.swagger:swagger-models:1.5.21")
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/witherview/account/AccountController.java
+++ b/src/main/java/com/witherview/account/AccountController.java
@@ -3,6 +3,7 @@ package com.witherview.account;
 import com.witherview.database.entity.User;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -18,6 +19,7 @@ import springfox.documentation.annotations.ApiIgnore;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
+@Api(tags = "Account API")
 @RestController
 @RequiredArgsConstructor
 public class AccountController {

--- a/src/main/java/com/witherview/account/AccountController.java
+++ b/src/main/java/com/witherview/account/AccountController.java
@@ -3,6 +3,7 @@ package com.witherview.account;
 import com.witherview.database.entity.User;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
@@ -23,10 +25,11 @@ public class AccountController {
     private final AccountService accountService;
     private final int SESSION_TIMEOUT = 1 * 60 * 60;
 
+    @ApiOperation(value="회원가입")
     @PostMapping(path = "/register", consumes = MediaType.APPLICATION_JSON_VALUE,
                                      produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> register(@RequestBody @Valid AccountDTO.RegisterDTO registerDTO,
-                                                       BindingResult result) {
+                                      BindingResult result) {
         if (result.hasErrors()) {
             ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
             return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
@@ -35,10 +38,11 @@ public class AccountController {
         return new ResponseEntity<>(modelMapper.map(user, AccountDTO.ResponseRegister.class), HttpStatus.CREATED);
     }
 
+    @ApiOperation(value="로그인")
     @PostMapping(path = "/login", consumes = MediaType.APPLICATION_JSON_VALUE,
                                   produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> login(@RequestBody @Valid AccountDTO.LoginDTO loginDTO,
-                                   BindingResult result, HttpSession session) {
+                                   BindingResult result, @ApiIgnore HttpSession session) {
         if (result.hasErrors()) {
             ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
             return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/witherview/configuration/InterceptorConfig.java
+++ b/src/main/java/com/witherview/configuration/InterceptorConfig.java
@@ -10,7 +10,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthInterceptor())
-                .addPathPatterns("/**")
-                .excludePathPatterns("/login", "/register", "/v2/api-docs", "/swagger-ui.html");
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/login", "/register", "/swagger-ui.html");
     }
 }

--- a/src/main/java/com/witherview/configuration/InterceptorConfig.java
+++ b/src/main/java/com/witherview/configuration/InterceptorConfig.java
@@ -11,6 +11,6 @@ public class InterceptorConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthInterceptor())
                 .addPathPatterns("/**")
-                .excludePathPatterns("/login", "/register");
+                .excludePathPatterns("/login", "/register", "/v2/api-docs", "/swagger-ui.html");
     }
 }

--- a/src/main/java/com/witherview/configuration/SwaggerConfig.java
+++ b/src/main/java/com/witherview/configuration/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.witherview.configuration;
+
+import io.swagger.annotations.ApiOperation;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import static springfox.documentation.builders.RequestHandlerSelectors.withMethodAnnotation;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig extends WebMvcConfigurationSupport {
+    private String title;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("swagger-ui.html")
+                .addResourceLocations("classpath:/META-INF/resources/");
+        registry.addResourceHandler("/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/");
+    }
+
+    @Bean
+    public Docket apiV1() {
+        title = "Witherview API ";
+
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(withMethodAnnotation(ApiOperation.class))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo(title))
+                .useDefaultResponseMessages(false);
+    }
+
+    private ApiInfo apiInfo(String title) {
+        return new ApiInfoBuilder()
+                .title(title)
+                .description("Witherview API DOCS")
+                .build();
+    }
+}

--- a/src/main/java/com/witherview/configuration/SwaggerConfig.java
+++ b/src/main/java/com/witherview/configuration/SwaggerConfig.java
@@ -3,8 +3,6 @@ package com.witherview.configuration;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
@@ -15,16 +13,8 @@ import static springfox.documentation.builders.RequestHandlerSelectors.withMetho
 
 @Configuration
 @EnableSwagger2
-public class SwaggerConfig extends WebMvcConfigurationSupport {
+public class SwaggerConfig {
     private String title;
-
-    @Override
-    public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("swagger-ui.html")
-                .addResourceLocations("classpath:/META-INF/resources/");
-        registry.addResourceHandler("/webjars/**")
-                .addResourceLocations("classpath:/META-INF/resources/webjars/");
-    }
 
     @Bean
     public Docket apiV1() {

--- a/src/main/java/com/witherview/database/entity/Question.java
+++ b/src/main/java/com/witherview/database/entity/Question.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotNull;
 @Table(name = "tbl_question")
 public class Question {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/witherview/database/entity/QuestionList.java
+++ b/src/main/java/com/witherview/database/entity/QuestionList.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Table(name = "tbl_question_list")
 public class QuestionList {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -34,7 +34,7 @@ public class QuestionList {
     @Column(nullable = false)
     private String job;
 
-    @OneToMany(mappedBy = "belongList", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "belongList", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Question> questions = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/witherview/database/entity/QuestionList.java
+++ b/src/main/java/com/witherview/database/entity/QuestionList.java
@@ -34,7 +34,7 @@ public class QuestionList {
     @Column(nullable = false)
     private String job;
 
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "belongList", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "belongList", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Question> questions = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/witherview/database/entity/User.java
+++ b/src/main/java/com/witherview/database/entity/User.java
@@ -47,7 +47,7 @@ public class User extends CreatedBaseEntity {
     @ColumnDefault("0")
     private Byte reliability;
 
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<QuestionList> questionLists = new ArrayList<>();
 
     @OneToMany(mappedBy = "host", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/witherview/database/entity/User.java
+++ b/src/main/java/com/witherview/database/entity/User.java
@@ -47,7 +47,7 @@ public class User extends CreatedBaseEntity {
     @ColumnDefault("0")
     private Byte reliability;
 
-    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<QuestionList> questionLists = new ArrayList<>();
 
     @OneToMany(mappedBy = "host", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/witherview/selfPractice/Question/SelfQuestionApiController.java
+++ b/src/main/java/com/witherview/selfPractice/Question/SelfQuestionApiController.java
@@ -4,6 +4,8 @@ import com.witherview.database.entity.Question;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
 import com.witherview.selfPractice.CustomValidator;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
@@ -12,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -25,11 +28,12 @@ public class SelfQuestionApiController {
     private final CustomValidator customValidator;
 
     // 질문 등록
+    @ApiOperation(value="질문 등록")
     @PostMapping(path = "/self/question", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> saveQuestion(@RequestBody @Valid SelfQuestionDTO.SaveDTO requestDto,
+    public ResponseEntity<?> saveQuestion(@RequestBody @Valid SelfQuestionDTO.QuestionSaveDTO requestDto,
                                           BindingResult result,
-                                          Errors errors) {
+                                          @ApiIgnore Errors errors) {
         // requestDTO 객체 검사
         if(result.hasErrors()) {
             ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
@@ -49,10 +53,11 @@ public class SelfQuestionApiController {
     }
 
     // 질문 수정
+    @ApiOperation(value="질문 수정")
     @PatchMapping(path = "/self/question", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> updateQuestion(@RequestBody List<SelfQuestionDTO.UpdateDTO> requestDto,
-                                  Errors errors) {
+    public ResponseEntity<?> updateQuestion(@RequestBody List<SelfQuestionDTO.QuestionUpdateDTO> requestDto,
+                                            @ApiIgnore Errors errors) {
 
         customValidator.validate(requestDto, errors);
 
@@ -70,15 +75,17 @@ public class SelfQuestionApiController {
     }
 
     // 모든 질문 조회
+    @ApiOperation(value="질문 조회")
     @GetMapping(path = "/self/question")
-    public ResponseEntity<?> findAllQuestion(@RequestParam("listId") Long listId) {
+    public ResponseEntity<?> findAllQuestion(@ApiParam(value = "조회할 질문리스트 id", required = true) @RequestParam("listId") Long listId) {
         List<Question> lists = selfQuestionService.findAllQuestions(listId);
         return new ResponseEntity<>(modelMapper.map(lists, SelfQuestionDTO.ResponseDTO[].class), HttpStatus.OK);
     }
 
     // 질문 삭제
+    @ApiOperation(value="질문 삭제")
     @DeleteMapping(path = "/self/question/{id}")
-    public ResponseEntity<?> deleteQuestion(@PathVariable Long id) {
+    public ResponseEntity<?> deleteQuestion(@ApiParam(value = "삭제할 질문 id", required = true) @PathVariable Long id) {
         Question deletedQuestion = selfQuestionService.delete(id);
         return new ResponseEntity<>(modelMapper.map(deletedQuestion, SelfQuestionDTO.DeleteResponseDTO.class), HttpStatus.OK);
     }

--- a/src/main/java/com/witherview/selfPractice/Question/SelfQuestionApiController.java
+++ b/src/main/java/com/witherview/selfPractice/Question/SelfQuestionApiController.java
@@ -31,7 +31,7 @@ public class SelfQuestionApiController {
 
     // 질문 등록
     @ApiOperation(value="질문 등록")
-    @PostMapping(path = "/self/question", consumes = MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping(path = "/api/self/question", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> saveQuestion(@RequestBody @Valid SelfQuestionDTO.QuestionSaveDTO requestDto,
                                           BindingResult result,
@@ -56,7 +56,7 @@ public class SelfQuestionApiController {
 
     // 질문 수정
     @ApiOperation(value="질문 수정")
-    @PatchMapping(path = "/self/question", consumes = MediaType.APPLICATION_JSON_VALUE,
+    @PatchMapping(path = "/api/self/question", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> updateQuestion(@RequestBody List<SelfQuestionDTO.QuestionUpdateDTO> requestDto,
                                             @ApiIgnore Errors errors) {
@@ -78,7 +78,7 @@ public class SelfQuestionApiController {
 
     // 모든 질문 조회
     @ApiOperation(value="질문 조회")
-    @GetMapping(path = "/self/question")
+    @GetMapping(path = "/api/self/question")
     public ResponseEntity<?> findAllQuestion(@ApiParam(value = "조회할 질문리스트 id", required = true) @RequestParam("listId") Long listId) {
         List<Question> lists = selfQuestionService.findAllQuestions(listId);
         return new ResponseEntity<>(modelMapper.map(lists, SelfQuestionDTO.ResponseDTO[].class), HttpStatus.OK);
@@ -86,7 +86,7 @@ public class SelfQuestionApiController {
 
     // 질문 삭제
     @ApiOperation(value="질문 삭제")
-    @DeleteMapping(path = "/self/question/{id}")
+    @DeleteMapping(path = "/api/self/question/{id}")
     public ResponseEntity<?> deleteQuestion(@ApiParam(value = "삭제할 질문 id", required = true) @PathVariable Long id) {
         Question deletedQuestion = selfQuestionService.delete(id);
         return new ResponseEntity<>(modelMapper.map(deletedQuestion, SelfQuestionDTO.DeleteResponseDTO.class), HttpStatus.OK);

--- a/src/main/java/com/witherview/selfPractice/Question/SelfQuestionApiController.java
+++ b/src/main/java/com/witherview/selfPractice/Question/SelfQuestionApiController.java
@@ -4,6 +4,7 @@ import com.witherview.database.entity.Question;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
 import com.witherview.selfPractice.CustomValidator;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Api(tags = "Question API")
 @RequiredArgsConstructor
 @RestController
 public class SelfQuestionApiController {

--- a/src/main/java/com/witherview/selfPractice/Question/SelfQuestionDTO.java
+++ b/src/main/java/com/witherview/selfPractice/Question/SelfQuestionDTO.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class SelfQuestionDTO {
 
     @Getter @Setter
-    public static class SaveDTO {
+    public static class QuestionSaveDTO {
         @NotNull(message = "리스트 아이디는 반드시 입력해야 합니다.")
         private Long listId;
 
@@ -42,7 +42,7 @@ public class SelfQuestionDTO {
     }
 
     @Getter @Setter @Builder
-    public static class UpdateDTO {
+    public static class QuestionUpdateDTO {
         @NotNull(message = "질문 id는 반드시 입력해야 합니다.")
         private Long id;
 

--- a/src/main/java/com/witherview/selfPractice/Question/SelfQuestionService.java
+++ b/src/main/java/com/witherview/selfPractice/Question/SelfQuestionService.java
@@ -21,7 +21,7 @@ public class SelfQuestionService {
     private final QuestionRepository questionRepository;
 
     @Transactional
-    public List<Question> save(SelfQuestionDTO.SaveDTO requestDto) {
+    public List<Question> save(SelfQuestionDTO.QuestionSaveDTO requestDto) {
         QuestionList questionList = questionListRepository.findById(requestDto.getListId())
                 .orElseThrow(() -> new NotFoundQuestionList());
 
@@ -35,7 +35,7 @@ public class SelfQuestionService {
     }
 
     @Transactional
-    public void update(List<SelfQuestionDTO.UpdateDTO> requestDto) {
+    public void update(List<SelfQuestionDTO.QuestionUpdateDTO> requestDto) {
         requestDto.stream()
                 .forEach(dto -> {
                     Question question = findQuestion(dto.getId());

--- a/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListApiController.java
+++ b/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListApiController.java
@@ -5,6 +5,8 @@ import com.witherview.database.entity.QuestionList;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
 import com.witherview.selfPractice.CustomValidator;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
@@ -13,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
@@ -27,11 +30,12 @@ public class SelfQuestionListApiController {
     private final CustomValidator customValidator;
 
     // 질문 리스트 등록
+    @ApiOperation(value="질문리스트 등록")
     @PostMapping(path = "/self/questionList", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> saveList(@RequestBody @Valid SelfQuestionListDTO.SaveDTO requestDto,
+    public ResponseEntity<?> saveList(@RequestBody @Valid SelfQuestionListDTO.QuestionListSaveDTO requestDto,
                                       BindingResult result,
-                                      HttpSession session) {
+                                      @ApiIgnore HttpSession session) {
         if(result.hasErrors()) {
             ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
             return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
@@ -42,18 +46,20 @@ public class SelfQuestionListApiController {
     }
 
     // 모든 질문 리스트 조회
+    @ApiOperation(value="질문리스트 조회")
     @GetMapping(path = "/self/questionList")
-    public ResponseEntity<?> findList(HttpSession session) {
+    public ResponseEntity<?> findList(@ApiIgnore HttpSession session) {
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
         List<QuestionList> lists = selfQuestionListService.findAllLists(accountSession.getId());
         return new ResponseEntity<>(modelMapper.map(lists, SelfQuestionListDTO.ResponseDTO[].class), HttpStatus.OK);
     }
 
     // 질문 리스트 수정
+    @ApiOperation(value="질문리스트 수정")
     @PatchMapping(path = "/self/questionList", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> updateList(@RequestBody List<SelfQuestionListDTO.UpdateDTO> requestDto,
-                                         Errors errors) {
+    public ResponseEntity<?> updateList(@RequestBody List<SelfQuestionListDTO.QuestionListUpdateDTO> requestDto,
+                                        @ApiIgnore Errors errors) {
 
         customValidator.validate(requestDto, errors);
 
@@ -71,8 +77,9 @@ public class SelfQuestionListApiController {
     }
 
     // 질문 리스트 삭제
+    @ApiOperation(value="질문리스트 삭제")
     @DeleteMapping(path = "/self/questionList/{id}")
-    public ResponseEntity<?> deleteList(@PathVariable Long id) {
+    public ResponseEntity<?> deleteList(@ApiParam(value = "삭제할 질문리스트 id", required = true) @PathVariable Long id) {
         QuestionList deletedList = selfQuestionListService.deleteList(id);
         return new ResponseEntity<>(modelMapper.map(deletedList, SelfQuestionListDTO.DeleteResponseDTO.class), HttpStatus.OK);
     }

--- a/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListApiController.java
+++ b/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListApiController.java
@@ -33,7 +33,7 @@ public class SelfQuestionListApiController {
 
     // 질문 리스트 등록
     @ApiOperation(value="질문리스트 등록")
-    @PostMapping(path = "/self/questionList", consumes = MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping(path = "/api/self/questionList", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> saveList(@RequestBody @Valid SelfQuestionListDTO.QuestionListSaveDTO requestDto,
                                       BindingResult result,
@@ -49,7 +49,7 @@ public class SelfQuestionListApiController {
 
     // 모든 질문 리스트 조회
     @ApiOperation(value="질문리스트 조회")
-    @GetMapping(path = "/self/questionList")
+    @GetMapping(path = "/api/self/questionList")
     public ResponseEntity<?> findList(@ApiIgnore HttpSession session) {
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
         List<QuestionList> lists = selfQuestionListService.findAllLists(accountSession.getId());
@@ -58,7 +58,7 @@ public class SelfQuestionListApiController {
 
     // 질문 리스트 수정
     @ApiOperation(value="질문리스트 수정")
-    @PatchMapping(path = "/self/questionList", consumes = MediaType.APPLICATION_JSON_VALUE,
+    @PatchMapping(path = "/api/self/questionList", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> updateList(@RequestBody List<SelfQuestionListDTO.QuestionListUpdateDTO> requestDto,
                                         @ApiIgnore Errors errors) {
@@ -80,7 +80,7 @@ public class SelfQuestionListApiController {
 
     // 질문 리스트 삭제
     @ApiOperation(value="질문리스트 삭제")
-    @DeleteMapping(path = "/self/questionList/{id}")
+    @DeleteMapping(path = "/api/self/questionList/{id}")
     public ResponseEntity<?> deleteList(@ApiParam(value = "삭제할 질문리스트 id", required = true) @PathVariable Long id) {
         QuestionList deletedList = selfQuestionListService.deleteList(id);
         return new ResponseEntity<>(modelMapper.map(deletedList, SelfQuestionListDTO.DeleteResponseDTO.class), HttpStatus.OK);

--- a/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListApiController.java
+++ b/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListApiController.java
@@ -5,6 +5,7 @@ import com.witherview.database.entity.QuestionList;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
 import com.witherview.selfPractice.CustomValidator;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Api(tags = "QuestionList API")
 @RequiredArgsConstructor
 @RestController
 public class SelfQuestionListApiController {

--- a/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListApiController.java
+++ b/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListApiController.java
@@ -1,5 +1,6 @@
 package com.witherview.selfPractice.QuestionList;
 
+import com.witherview.account.AccountSession;
 import com.witherview.database.entity.QuestionList;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
@@ -24,24 +25,27 @@ public class SelfQuestionListApiController {
     private final ModelMapper modelMapper;
     private final SelfQuestionListService selfQuestionListService;
     private final CustomValidator customValidator;
-    private final long userId = 1; // 임시
 
     // 질문 리스트 등록
     @PostMapping(path = "/self/questionList", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> saveList(@RequestBody @Valid SelfQuestionListDTO.SaveDTO requestDto, BindingResult result) {
+    public ResponseEntity<?> saveList(@RequestBody @Valid SelfQuestionListDTO.SaveDTO requestDto,
+                                      BindingResult result,
+                                      HttpSession session) {
         if(result.hasErrors()) {
             ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
             return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
         }
-        QuestionList questionList = selfQuestionListService.saveList(userId, requestDto);
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        QuestionList questionList = selfQuestionListService.saveList(accountSession.getId(), requestDto);
         return new ResponseEntity<>(modelMapper.map(questionList, SelfQuestionListDTO.ResponseDTO.class), HttpStatus.CREATED);
     }
 
     // 모든 질문 리스트 조회
     @GetMapping(path = "/self/questionList")
     public ResponseEntity<?> findList(HttpSession session) {
-        List<QuestionList> lists = selfQuestionListService.findAllLists(userId);
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        List<QuestionList> lists = selfQuestionListService.findAllLists(accountSession.getId());
         return new ResponseEntity<>(modelMapper.map(lists, SelfQuestionListDTO.ResponseDTO[].class), HttpStatus.OK);
     }
 

--- a/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListDTO.java
+++ b/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListDTO.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 public class SelfQuestionListDTO {
 
     @Getter @Setter @Builder
-    public static class SaveDTO {
+    public static class QuestionListSaveDTO {
         @NotBlank(message = "질문리스트 제목은 반드시 입력해야 합니다.")
         private String title;
 
@@ -31,7 +31,7 @@ public class SelfQuestionListDTO {
     }
 
     @Getter @Setter @Builder
-    public static class UpdateDTO {
+    public static class QuestionListUpdateDTO {
         @NotNull(message = "질문리스트 아이디는 반드시 입력해야 합니다.")
         private Long id;
 

--- a/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListService.java
+++ b/src/main/java/com/witherview/selfPractice/QuestionList/SelfQuestionListService.java
@@ -21,7 +21,7 @@ public class SelfQuestionListService {
     private final UserRepository userRepository;
 
     @Transactional
-    public QuestionList saveList(Long userId, SelfQuestionListDTO.SaveDTO requestDto) {
+    public QuestionList saveList(Long userId, SelfQuestionListDTO.QuestionListSaveDTO requestDto) {
         QuestionList questionList = requestDto.toEntity();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundUser());
@@ -31,7 +31,7 @@ public class SelfQuestionListService {
     }
 
     @Transactional
-    public void updateList(List<SelfQuestionListDTO.UpdateDTO> requestDto) {
+    public void updateList(List<SelfQuestionListDTO.QuestionListUpdateDTO> requestDto) {
         requestDto.stream().forEach(dto -> {
             QuestionList questionList = findList(dto.getId());
             questionList.update(dto.getTitle(), dto.getEnterprise(), dto.getJob());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
@@ -26,7 +26,7 @@ spring:
   mvc:
     throw-exception-if-no-handler-found: true
   resources:
-    add-mappings: false
+    add-mappings: true
 
 logging:
   level:
@@ -51,7 +51,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
+++ b/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
@@ -12,26 +12,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.Rollback;
 
 import javax.transaction.Transactional;
 
+@Transactional
 public class SelfPracticeSupporter extends MockMvcSupporter {
     final Long userId = (long)1;
     final String email = "hohoho@witherview.com";
     final String password = "123456";
     final String name = "witherview";
 
+    final Long failedListId = (long) 3;
     // questionlist
+    Long listId = (long) 1;
     final String title = "개발자 스터디 모집해요.";
     final String enterprise = "kakao";
     final String job = "sw 개발자";
-    final Long listId = (long) 1;
-    final Long failedListId = (long) 3;
     final String updatedTitle = "기획자 스터디 모집합니다.";
     final String updatedEnterprise = "naver";
-
     // question
-    final Long questionId = (long) 1;
+    Long questionId = (long) 1;
     final Long failedQuestionId = (long) 3;
     final String question = "당신의 주 언어는 무엇인가요?";
     final String answer = "저의 주 언어는 ~~입니다";
@@ -51,23 +52,23 @@ public class SelfPracticeSupporter extends MockMvcSupporter {
     PasswordEncoder passwordEncoder;
 
     @BeforeEach
-    public void 회원가입and세션생성() {
+    public void 회원가입_세션생성_리스트생성() {
         User user = userRepository.findByEmail(email);
+        // 회원가입
         if (user == null) {
-            userRepository.save(new User(email, passwordEncoder.encode(password), name));
+            user = userRepository.save(new User(email, passwordEncoder.encode(password), name));
         }
-
-        AccountSession accountSession = new AccountSession(userId, email, name);
-        mockHttpSession.setAttribute("user", accountSession);
-    }
-
-    // 질문 test 코드 및 질문리스트 수정 test 코드를 위해 미리 질문리스트 하나 생성해두기
-    @BeforeEach @Transactional
-    public void 미리질문리스트등록() {
+        // 세션생성
+        if(mockHttpSession.getAttribute("user") == null) {
+            AccountSession accountSession = new AccountSession(userId, email, name);
+            mockHttpSession.setAttribute("user", accountSession);
+        }
+        // 리스트생성
         QuestionList questionList = new QuestionList("title", "enterprise", "job");
-        User user = userRepository.findByEmail(email);
-        user.addQuestionList(questionList);
-
-        questionListRepository.save(questionList);
+        if(questionListRepository.count() == 0) {
+            user.addQuestionList(questionList);
+            listId = questionListRepository.save(questionList).getId();
+        }
+        System.out.println("list id " + listId);
     }
 }

--- a/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
+++ b/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
@@ -1,0 +1,36 @@
+package com.witherview.selfPractice;
+
+import com.witherview.account.AccountSession;
+import com.witherview.support.MockMvcSupporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.mock.web.MockHttpSession;
+
+public class SelfPracticeSupporter extends MockMvcSupporter {
+    final Long userId = (long)1;
+    final String email = "hohoho@witherview.com";
+    final String name = "witherview";
+
+    // questionlist
+    final String title = "개발자 스터디 모집해요.";
+    final String enterprise = "kakao";
+    final String job = "sw 개발자";
+    final Long listId = (long) 4;
+    final String updatedTitle = "기획자 스터디 모집합니다.";
+    final String updatedEnterprise = "naver";
+
+    // question
+    final Long questionId = (long) 5;
+    final String question = "당신의 주 언어는 무엇인가요?";
+    final String answer = "저의 주 언어는 ~~입니다";
+    final Integer order = 1;
+    final String updatedQuestion = "당신의 입사 후 목표는 무엇인가요?";
+    final String updatedAnswer = "저의 목표는 ~입니다.";
+
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+
+    @BeforeEach
+    public void 세션생성() {
+        AccountSession accountSession = new AccountSession(userId, email, name);
+        mockHttpSession.setAttribute("user", accountSession);
+    }
+}

--- a/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
+++ b/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
@@ -14,12 +14,12 @@ public class SelfPracticeSupporter extends MockMvcSupporter {
     final String title = "개발자 스터디 모집해요.";
     final String enterprise = "kakao";
     final String job = "sw 개발자";
-    final Long listId = (long) 4;
+    final Long listId = (long) 2;
     final String updatedTitle = "기획자 스터디 모집합니다.";
     final String updatedEnterprise = "naver";
 
     // question
-    final Long questionId = (long) 5;
+    final Long questionId = (long) 1;
     final String question = "당신의 주 언어는 무엇인가요?";
     final String answer = "저의 주 언어는 ~~입니다";
     final Integer order = 1;

--- a/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
+++ b/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
@@ -1,25 +1,38 @@
 package com.witherview.selfPractice;
 
 import com.witherview.account.AccountSession;
+import com.witherview.database.entity.QuestionList;
+import com.witherview.database.entity.User;
+import com.witherview.database.repository.QuestionListRepository;
+import com.witherview.database.repository.UserRepository;
+import com.witherview.selfPractice.exception.NotFoundUser;
 import com.witherview.support.MockMvcSupporter;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.transaction.Transactional;
 
 public class SelfPracticeSupporter extends MockMvcSupporter {
     final Long userId = (long)1;
     final String email = "hohoho@witherview.com";
+    final String password = "123456";
     final String name = "witherview";
 
     // questionlist
     final String title = "개발자 스터디 모집해요.";
     final String enterprise = "kakao";
     final String job = "sw 개발자";
-    final Long listId = (long) 2;
+    final Long listId = (long) 1;
+    final Long failedListId = (long) 3;
     final String updatedTitle = "기획자 스터디 모집합니다.";
     final String updatedEnterprise = "naver";
 
     // question
     final Long questionId = (long) 1;
+    final Long failedQuestionId = (long) 3;
     final String question = "당신의 주 언어는 무엇인가요?";
     final String answer = "저의 주 언어는 ~~입니다";
     final Integer order = 1;
@@ -28,9 +41,33 @@ public class SelfPracticeSupporter extends MockMvcSupporter {
 
     final MockHttpSession mockHttpSession = new MockHttpSession();
 
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    QuestionListRepository questionListRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
     @BeforeEach
-    public void 세션생성() {
+    public void 회원가입and세션생성() {
+        User user = userRepository.findByEmail(email);
+        if (user == null) {
+            userRepository.save(new User(email, passwordEncoder.encode(password), name));
+        }
+
         AccountSession accountSession = new AccountSession(userId, email, name);
         mockHttpSession.setAttribute("user", accountSession);
+    }
+
+    // 질문 test 코드 및 질문리스트 수정 test 코드를 위해 미리 질문리스트 하나 생성해두기
+    @BeforeEach @Transactional
+    public void 미리질문리스트등록() {
+        QuestionList questionList = new QuestionList("title", "enterprise", "job");
+        User user = userRepository.findByEmail(email);
+        user.addQuestionList(questionList);
+
+        questionListRepository.save(questionList);
     }
 }

--- a/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
+++ b/src/test/java/com/witherview/selfPractice/SelfPracticeSupporter.java
@@ -69,6 +69,5 @@ public class SelfPracticeSupporter extends MockMvcSupporter {
             user.addQuestionList(questionList);
             listId = questionListRepository.save(questionList).getId();
         }
-        System.out.println("list id " + listId);
     }
 }

--- a/src/test/java/com/witherview/selfPractice/SelfQuestionApiTest.java
+++ b/src/test/java/com/witherview/selfPractice/SelfQuestionApiTest.java
@@ -1,10 +1,17 @@
 package com.witherview.selfPractice;
 
+import com.witherview.database.entity.Question;
+import com.witherview.database.entity.QuestionList;
+import com.witherview.database.repository.QuestionRepository;
 import com.witherview.selfPractice.Question.SelfQuestionDTO;
+import com.witherview.selfPractice.exception.NotFoundQuestionList;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,6 +22,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class SelfQuestionApiTest extends SelfPracticeSupporter {
+
+    @Autowired
+    QuestionRepository questionRepository;
+
+    @BeforeEach @Transactional
+    public void 미리질문등록() {
+        QuestionList questionList = questionListRepository.findById(listId)
+                .orElseThrow(() -> new NotFoundQuestionList());
+        Question question = new Question("question", "answer", 1);
+        questionList.addQuestion(question);
+        questionRepository.save(question);
+    }
 
     @Test
     public void 질문_등록성공() throws Exception {
@@ -131,7 +150,7 @@ public class SelfQuestionApiTest extends SelfPracticeSupporter {
         list.add(questionDTO);
 
         SelfQuestionDTO.QuestionSaveDTO requestDTO = new SelfQuestionDTO.QuestionSaveDTO();
-        requestDTO.setListId(listId);
+        requestDTO.setListId(failedListId);
         requestDTO.setQuestions(list);
 
         ResultActions resultActions = mockMvc.perform(post("/api/self/question")
@@ -149,7 +168,7 @@ public class SelfQuestionApiTest extends SelfPracticeSupporter {
     @Test
     public void 질문_수정실패_없는_질문() throws Exception {
         SelfQuestionDTO.QuestionUpdateDTO dto = SelfQuestionDTO.QuestionUpdateDTO.builder()
-                .id(questionId)
+                .id(failedQuestionId)
                 .question(updatedQuestion)
                 .answer(updatedAnswer)
                 .order(order)

--- a/src/test/java/com/witherview/selfPractice/SelfQuestionApiTest.java
+++ b/src/test/java/com/witherview/selfPractice/SelfQuestionApiTest.java
@@ -21,18 +21,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Transactional
 public class SelfQuestionApiTest extends SelfPracticeSupporter {
 
     @Autowired
     QuestionRepository questionRepository;
 
-    @BeforeEach @Transactional
+    @BeforeEach
     public void 미리질문등록() {
         QuestionList questionList = questionListRepository.findById(listId)
                 .orElseThrow(() -> new NotFoundQuestionList());
-        Question question = new Question("question", "answer", 1);
-        questionList.addQuestion(question);
-        questionRepository.save(question);
+
+        if(questionRepository.count() == 0) {
+            Question question = new Question("question", "answer", 1);
+            questionList.addQuestion(question);
+            questionId = questionRepository.save(question).getId();
+        }
     }
 
     @Test

--- a/src/test/java/com/witherview/selfPractice/SelfQuestionApiTest.java
+++ b/src/test/java/com/witherview/selfPractice/SelfQuestionApiTest.java
@@ -1,7 +1,6 @@
 package com.witherview.selfPractice;
 
 import com.witherview.selfPractice.Question.SelfQuestionDTO;
-import com.witherview.support.MockMvcSupporter;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -15,13 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class SelfQuestionApiTest extends MockMvcSupporter {
-    final Long id = (long) 5;
-    final String question = "당신의 주 언어는 무엇인가요?";
-    final String answer = "저의 주 언어는 ~~입니다";
-    final Integer order = 1;
-    final String updatedQuestion = "당신의 입사 후 목표는 무엇인가요?";
-    final String updatedAnswer = "저의 목표는 ~입니다.";
+public class SelfQuestionApiTest extends SelfPracticeSupporter {
 
     @Test
     public void 질문_등록성공() throws Exception {
@@ -34,11 +27,12 @@ public class SelfQuestionApiTest extends MockMvcSupporter {
         List<SelfQuestionDTO.QuestionDTO> list = new ArrayList<>();
         list.add(questionDTO);
 
-        SelfQuestionDTO.SaveDTO requestDTO = new SelfQuestionDTO.SaveDTO();
-        requestDTO.setListId(id);
+        SelfQuestionDTO.QuestionSaveDTO requestDTO = new SelfQuestionDTO.QuestionSaveDTO();
+        requestDTO.setListId(listId);
         requestDTO.setQuestions(list);
 
         ResultActions resultActions = mockMvc.perform(post("/self/question")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(requestDTO)))
@@ -52,17 +46,18 @@ public class SelfQuestionApiTest extends MockMvcSupporter {
 
     @Test
     public void 질문_수정성공() throws Exception {
-        SelfQuestionDTO.UpdateDTO dto = SelfQuestionDTO.UpdateDTO.builder()
-                .id(id)
+        SelfQuestionDTO.QuestionUpdateDTO dto = SelfQuestionDTO.QuestionUpdateDTO.builder()
+                .id(questionId)
                 .question(updatedQuestion)
                 .answer(updatedAnswer)
                 .order(order)
                 .build();
 
-        List<SelfQuestionDTO.UpdateDTO> list = new ArrayList<>();
+        List<SelfQuestionDTO.QuestionUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
         ResultActions resultActions = mockMvc.perform(patch("/self/question")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(list)))
@@ -84,11 +79,12 @@ public class SelfQuestionApiTest extends MockMvcSupporter {
         List<SelfQuestionDTO.QuestionDTO> list = new ArrayList<>();
         list.add(questionDTO);
 
-        SelfQuestionDTO.SaveDTO requestDTO = new SelfQuestionDTO.SaveDTO();
-        requestDTO.setListId(id);
+        SelfQuestionDTO.QuestionSaveDTO requestDTO = new SelfQuestionDTO.QuestionSaveDTO();
+        requestDTO.setListId(listId);
         requestDTO.setQuestions(list);
 
         ResultActions resultActions = mockMvc.perform(post("/self/question")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(requestDTO)))
@@ -101,17 +97,18 @@ public class SelfQuestionApiTest extends MockMvcSupporter {
 
     @Test
     public void 질문_수정실패_입력값_공백() throws Exception {
-        SelfQuestionDTO.UpdateDTO dto = SelfQuestionDTO.UpdateDTO.builder()
-                .id(id)
+        SelfQuestionDTO.QuestionUpdateDTO dto = SelfQuestionDTO.QuestionUpdateDTO.builder()
+                .id(questionId)
                 .question("")
                 .answer(updatedAnswer)
                 .order(order)
                 .build();
 
-        List<SelfQuestionDTO.UpdateDTO> list = new ArrayList<>();
+        List<SelfQuestionDTO.QuestionUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
         ResultActions resultActions = mockMvc.perform(patch("/self/question")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(list)))
@@ -133,11 +130,12 @@ public class SelfQuestionApiTest extends MockMvcSupporter {
         List<SelfQuestionDTO.QuestionDTO> list = new ArrayList<>();
         list.add(questionDTO);
 
-        SelfQuestionDTO.SaveDTO requestDTO = new SelfQuestionDTO.SaveDTO();
-        requestDTO.setListId(id);
+        SelfQuestionDTO.QuestionSaveDTO requestDTO = new SelfQuestionDTO.QuestionSaveDTO();
+        requestDTO.setListId(listId);
         requestDTO.setQuestions(list);
 
         ResultActions resultActions = mockMvc.perform(post("/self/question")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(requestDTO)))
@@ -150,17 +148,18 @@ public class SelfQuestionApiTest extends MockMvcSupporter {
 
     @Test
     public void 질문_수정실패_없는_질문() throws Exception {
-        SelfQuestionDTO.UpdateDTO dto = SelfQuestionDTO.UpdateDTO.builder()
-                .id(id)
+        SelfQuestionDTO.QuestionUpdateDTO dto = SelfQuestionDTO.QuestionUpdateDTO.builder()
+                .id(questionId)
                 .question(updatedQuestion)
                 .answer(updatedAnswer)
                 .order(order)
                 .build();
 
-        List<SelfQuestionDTO.UpdateDTO> list = new ArrayList<>();
+        List<SelfQuestionDTO.QuestionUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
         ResultActions resultActions = mockMvc.perform(patch("/self/question")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(list)))

--- a/src/test/java/com/witherview/selfPractice/SelfQuestionApiTest.java
+++ b/src/test/java/com/witherview/selfPractice/SelfQuestionApiTest.java
@@ -31,7 +31,7 @@ public class SelfQuestionApiTest extends SelfPracticeSupporter {
         requestDTO.setListId(listId);
         requestDTO.setQuestions(list);
 
-        ResultActions resultActions = mockMvc.perform(post("/self/question")
+        ResultActions resultActions = mockMvc.perform(post("/api/self/question")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -56,7 +56,7 @@ public class SelfQuestionApiTest extends SelfPracticeSupporter {
         List<SelfQuestionDTO.QuestionUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
-        ResultActions resultActions = mockMvc.perform(patch("/self/question")
+        ResultActions resultActions = mockMvc.perform(patch("/api/self/question")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -83,7 +83,7 @@ public class SelfQuestionApiTest extends SelfPracticeSupporter {
         requestDTO.setListId(listId);
         requestDTO.setQuestions(list);
 
-        ResultActions resultActions = mockMvc.perform(post("/self/question")
+        ResultActions resultActions = mockMvc.perform(post("/api/self/question")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -107,7 +107,7 @@ public class SelfQuestionApiTest extends SelfPracticeSupporter {
         List<SelfQuestionDTO.QuestionUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
-        ResultActions resultActions = mockMvc.perform(patch("/self/question")
+        ResultActions resultActions = mockMvc.perform(patch("/api/self/question")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -134,7 +134,7 @@ public class SelfQuestionApiTest extends SelfPracticeSupporter {
         requestDTO.setListId(listId);
         requestDTO.setQuestions(list);
 
-        ResultActions resultActions = mockMvc.perform(post("/self/question")
+        ResultActions resultActions = mockMvc.perform(post("/api/self/question")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -158,7 +158,7 @@ public class SelfQuestionApiTest extends SelfPracticeSupporter {
         List<SelfQuestionDTO.QuestionUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
-        ResultActions resultActions = mockMvc.perform(patch("/self/question")
+        ResultActions resultActions = mockMvc.perform(patch("/api/self/question")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/com/witherview/selfPractice/SelfQuestionListApiTest.java
+++ b/src/test/java/com/witherview/selfPractice/SelfQuestionListApiTest.java
@@ -24,7 +24,7 @@ public class SelfQuestionListApiTest extends SelfPracticeSupporter {
                 .job(job)
                 .build();
 
-        ResultActions resultActions = mockMvc.perform(post("/self/questionList")
+        ResultActions resultActions = mockMvc.perform(post("/api/self/questionList")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -49,7 +49,7 @@ public class SelfQuestionListApiTest extends SelfPracticeSupporter {
         List<SelfQuestionListDTO.QuestionListUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
-        ResultActions resultActions = mockMvc.perform(patch("/self/questionList")
+        ResultActions resultActions = mockMvc.perform(patch("/api/self/questionList")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -69,7 +69,7 @@ public class SelfQuestionListApiTest extends SelfPracticeSupporter {
                 .job(job)
                 .build();
 
-        ResultActions resultActions = mockMvc.perform(post("/self/questionList")
+        ResultActions resultActions = mockMvc.perform(post("/api/self/questionList")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -89,7 +89,7 @@ public class SelfQuestionListApiTest extends SelfPracticeSupporter {
                 .job(job)
                 .build();
 
-        ResultActions resultActions = mockMvc.perform(post("/self/questionList")
+        ResultActions resultActions = mockMvc.perform(post("/api/self/questionList")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -113,7 +113,7 @@ public class SelfQuestionListApiTest extends SelfPracticeSupporter {
         List<SelfQuestionListDTO.QuestionListUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
-        ResultActions resultActions = mockMvc.perform(patch("/self/questionList")
+        ResultActions resultActions = mockMvc.perform(patch("/api/self/questionList")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -137,7 +137,7 @@ public class SelfQuestionListApiTest extends SelfPracticeSupporter {
         List<SelfQuestionListDTO.QuestionListUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
-        ResultActions resultActions = mockMvc.perform(patch("/self/questionList")
+        ResultActions resultActions = mockMvc.perform(patch("/api/self/questionList")
                 .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/com/witherview/selfPractice/SelfQuestionListApiTest.java
+++ b/src/test/java/com/witherview/selfPractice/SelfQuestionListApiTest.java
@@ -104,7 +104,7 @@ public class SelfQuestionListApiTest extends SelfPracticeSupporter {
     @Test
     public void 질문리스트_수정실패_없는_질문리스트() throws Exception {
         SelfQuestionListDTO.QuestionListUpdateDTO dto = SelfQuestionListDTO.QuestionListUpdateDTO.builder()
-                .id(listId)
+                .id(failedListId)
                 .title(updatedTitle)
                 .enterprise(updatedEnterprise)
                 .job(job)

--- a/src/test/java/com/witherview/selfPractice/SelfQuestionListApiTest.java
+++ b/src/test/java/com/witherview/selfPractice/SelfQuestionListApiTest.java
@@ -1,7 +1,6 @@
 package com.witherview.selfPractice;
 
 import com.witherview.selfPractice.QuestionList.SelfQuestionListDTO;
-import com.witherview.support.MockMvcSupporter;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -15,24 +14,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class SelfQuestionListApiTest extends MockMvcSupporter {
-
-    final String title = "개발자 스터디 모집해요.";
-    final String enterprise = "kakao";
-    final String job = "sw 개발자";
-    final Long id = (long) 2;
-    final String updatedTitle = "기획자 스터디 모집합니다.";
-    final String updatedEnterprise = "naver";
+public class SelfQuestionListApiTest extends SelfPracticeSupporter {
 
     @Test
     public void 질문리스트_등록성공() throws Exception {
-        SelfQuestionListDTO.SaveDTO dto = SelfQuestionListDTO.SaveDTO.builder()
+        SelfQuestionListDTO.QuestionListSaveDTO dto = SelfQuestionListDTO.QuestionListSaveDTO.builder()
                 .title(title)
                 .enterprise(enterprise)
                 .job(job)
                 .build();
 
         ResultActions resultActions = mockMvc.perform(post("/self/questionList")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -46,17 +39,18 @@ public class SelfQuestionListApiTest extends MockMvcSupporter {
 
     @Test
     public void 질문리스트_수정성공() throws Exception {
-        SelfQuestionListDTO.UpdateDTO dto = SelfQuestionListDTO.UpdateDTO.builder()
-                .id(id)
+        SelfQuestionListDTO.QuestionListUpdateDTO dto = SelfQuestionListDTO.QuestionListUpdateDTO.builder()
+                .id(listId)
                 .title(updatedTitle)
                 .enterprise(updatedEnterprise)
                 .job(job)
                 .build();
 
-        List<SelfQuestionListDTO.UpdateDTO> list = new ArrayList<>();
+        List<SelfQuestionListDTO.QuestionListUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
         ResultActions resultActions = mockMvc.perform(patch("/self/questionList")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(list)))
@@ -69,13 +63,14 @@ public class SelfQuestionListApiTest extends MockMvcSupporter {
 
     @Test
     public void 질문리스트_등록실패_없는_사용자() throws Exception {
-        SelfQuestionListDTO.SaveDTO dto = SelfQuestionListDTO.SaveDTO.builder()
+        SelfQuestionListDTO.QuestionListSaveDTO dto = SelfQuestionListDTO.QuestionListSaveDTO.builder()
                 .title(title)
                 .enterprise(enterprise)
                 .job(job)
                 .build();
 
         ResultActions resultActions = mockMvc.perform(post("/self/questionList")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -88,13 +83,14 @@ public class SelfQuestionListApiTest extends MockMvcSupporter {
 
     @Test
     public void 질문리스트_등록실패_입력값_공백() throws Exception {
-        SelfQuestionListDTO.SaveDTO dto = SelfQuestionListDTO.SaveDTO.builder()
+        SelfQuestionListDTO.QuestionListSaveDTO dto = SelfQuestionListDTO.QuestionListSaveDTO.builder()
                 .title("")
                 .enterprise(enterprise)
                 .job(job)
                 .build();
 
         ResultActions resultActions = mockMvc.perform(post("/self/questionList")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -107,17 +103,18 @@ public class SelfQuestionListApiTest extends MockMvcSupporter {
 
     @Test
     public void 질문리스트_수정실패_없는_질문리스트() throws Exception {
-        SelfQuestionListDTO.UpdateDTO dto = SelfQuestionListDTO.UpdateDTO.builder()
-                .id(id)
+        SelfQuestionListDTO.QuestionListUpdateDTO dto = SelfQuestionListDTO.QuestionListUpdateDTO.builder()
+                .id(listId)
                 .title(updatedTitle)
                 .enterprise(updatedEnterprise)
                 .job(job)
                 .build();
 
-        List<SelfQuestionListDTO.UpdateDTO> list = new ArrayList<>();
+        List<SelfQuestionListDTO.QuestionListUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
         ResultActions resultActions = mockMvc.perform(patch("/self/questionList")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(list)))
@@ -130,17 +127,18 @@ public class SelfQuestionListApiTest extends MockMvcSupporter {
 
     @Test
     public void 질문리스트_수정실패_입력값_공백() throws Exception {
-        SelfQuestionListDTO.UpdateDTO dto = SelfQuestionListDTO.UpdateDTO.builder()
-                .id(id)
+        SelfQuestionListDTO.QuestionListUpdateDTO dto = SelfQuestionListDTO.QuestionListUpdateDTO.builder()
+                .id(listId)
                 .title("")
                 .enterprise("")
                 .job(job)
                 .build();
 
-        List<SelfQuestionListDTO.UpdateDTO> list = new ArrayList<>();
+        List<SelfQuestionListDTO.QuestionListUpdateDTO> list = new ArrayList<>();
         list.add(dto);
 
         ResultActions resultActions = mockMvc.perform(patch("/self/questionList")
+                .session(mockHttpSession)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(list)))


### PR DESCRIPTION
## 수정 사항
- 세션에 저장된 유저 id 사용할 수 있도록 질문리스트 컨트롤러 수정

## 추가 사항 
- swagger 적용
서버 실행 후 http://localhost:8080/swagger-ui.html 에서 확인가능
<img width="350" alt="스크린샷 2020-11-13 오전 12 46 52" src="https://user-images.githubusercontent.com/34999925/98962415-f6e56080-2549-11eb-9c09-c2e604a17687.png">



## 참고 사항
- 프론트 분들 작업하시려면 저희 현재 만든 부분까지 yapp 서버에 올려야 할 것 같네용..