### PR TITLE
영상 업로드 및 HLS 변환 + 리소스 접근

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
 	compile("io.swagger:swagger-annotations:1.5.21")
 	compile("io.swagger:swagger-models:1.5.21")
 
+	// ffmpeg
+	compile group: 'net.bramp.ffmpeg', name: 'ffmpeg', version: '0.6.2'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/witherview/configuration/InterceptorConfig.java
+++ b/src/main/java/com/witherview/configuration/InterceptorConfig.java
@@ -10,7 +10,6 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthInterceptor())
-                .addPathPatterns("/api/**")
-                .excludePathPatterns("/login", "/register", "/swagger-ui.html");
+                .addPathPatterns("/api/**");
     }
 }

--- a/src/main/java/com/witherview/configuration/InterceptorConfig.java
+++ b/src/main/java/com/witherview/configuration/InterceptorConfig.java
@@ -1,6 +1,7 @@
 package com.witherview.configuration;
 
 import com.witherview.interceptor.AuthInterceptor;
+import com.witherview.interceptor.ResourceAuthInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -11,5 +12,8 @@ public class InterceptorConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthInterceptor())
                 .addPathPatterns("/api/**");
+
+        registry.addInterceptor(new ResourceAuthInterceptor())
+                .addPathPatterns("/videos/**");
     }
 }

--- a/src/main/java/com/witherview/configuration/WebConfig.java
+++ b/src/main/java/com/witherview/configuration/WebConfig.java
@@ -1,11 +1,22 @@
 package com.witherview.configuration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${upload.location}")
+    private String uploadLocation;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/videos/**")
+                .addResourceLocations("file:///" + uploadLocation);
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/witherview/database/entity/SelfHistory.java
+++ b/src/main/java/com/witherview/database/entity/SelfHistory.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Entity @Getter
 @NoArgsConstructor
@@ -22,6 +24,9 @@ public class SelfHistory extends CreatedBaseEntity {
     @JoinColumn(name = "question_list_id", nullable = false)
     private QuestionList questionList;
 
+    @NotNull @NotBlank
+    private String savedLocation;
+
     @Builder
     public SelfHistory(QuestionList questionList) {
         this.questionList = questionList;
@@ -29,5 +34,9 @@ public class SelfHistory extends CreatedBaseEntity {
 
     protected void updateUser(User user) {
         this.user = user;
+    }
+
+    public void updateSavedLocation(String savedLocation) {
+        this.savedLocation = savedLocation;
     }
 }

--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
     // Self-Practice
     NOT_FOUND_USER(404, "SELF-PRACTICE001", "해당 유저가 없습니다."),
     NOT_FOUND_QUESTIONLIST(404, "SELF-PRACTICE002", "해당 질문리스트가 없습니다."),
-    NOT_FOUND_QUESTION(404, "SELF-PRACTICE003", "해당 질문이 없습니다.");
+    NOT_FOUND_QUESTION(404, "SELF-PRACTICE003", "해당 질문이 없습니다."),
+
+    // Video
+    NOT_SAVED_VIDEO(500, "VIDEO001", "비디오를 저장하는데 실패하였습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/witherview/interceptor/ResourceAuthInterceptor.java
+++ b/src/main/java/com/witherview/interceptor/ResourceAuthInterceptor.java
@@ -1,0 +1,24 @@
+package com.witherview.interceptor;
+
+import com.witherview.account.AccountSession;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ResourceAuthInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        AccountSession accountSession = (AccountSession) request.getSession().getAttribute("user");
+        if (accountSession == null) return false;
+
+        int emailStartIdx = 8;
+        String fromEmailToEnd = request.getRequestURI().substring(emailStartIdx);
+        int slashIdx = fromEmailToEnd.indexOf("/");
+        if (slashIdx == -1) return false;
+
+        String requestEmail = fromEmailToEnd.substring(0, slashIdx);
+        return accountSession.getEmail().equals(requestEmail);
+    }
+}

--- a/src/main/java/com/witherview/selfPractice/history/SelfHistoryController.java
+++ b/src/main/java/com/witherview/selfPractice/history/SelfHistoryController.java
@@ -2,8 +2,6 @@ package com.witherview.selfPractice.history;
 
 import com.witherview.account.AccountSession;
 import com.witherview.database.entity.SelfHistory;
-import com.witherview.exception.ErrorCode;
-import com.witherview.exception.ErrorResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -11,15 +9,11 @@ import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpSession;
-import javax.validation.Valid;
 import java.util.List;
 
 @Api(tags = "SelfHistory API")
@@ -30,17 +24,13 @@ public class SelfHistoryController {
     private final SelfHistoryService selfHistoryService;
 
     @ApiOperation(value="혼자 연습 기록 등록")
-    @PostMapping(path = "/api/self/history", consumes = MediaType.APPLICATION_JSON_VALUE,
-                                            produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> save(@RequestBody @Valid SelfHistoryDTO.SelfHistorySaveDTO dto,
-                                      BindingResult result,
-                                      @ApiIgnore HttpSession session) {
-        if(result.hasErrors()) {
-            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
-            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-        }
+    @PostMapping(path = "/api/self/history", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                             produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> save(@RequestParam("videoFile") MultipartFile videoFile,
+                                  @RequestParam("questionListId") Long questionListId,
+                                  @ApiIgnore HttpSession session) {
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
-        SelfHistory selfHistory = selfHistoryService.save(dto, accountSession.getId());
+        SelfHistory selfHistory = selfHistoryService.save(videoFile, questionListId, accountSession);
         return new ResponseEntity<>(modelMapper.map(selfHistory,
                 SelfHistoryDTO.SelfHistorySaveResponseDTO.class), HttpStatus.CREATED);
     }

--- a/src/main/java/com/witherview/selfPractice/history/SelfHistoryDTO.java
+++ b/src/main/java/com/witherview/selfPractice/history/SelfHistoryDTO.java
@@ -3,17 +3,9 @@ package com.witherview.selfPractice.history;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public class SelfHistoryDTO {
-
-    @Getter @Setter
-    public static class SelfHistorySaveDTO {
-        @NotNull(message = "질문리스트 아이디는 반드시 입력해야 합니다.")
-        private Long questionListId;
-    }
-
     @Getter @Setter
     public static class SelfHistorySaveResponseDTO {
         private Long id;
@@ -25,6 +17,7 @@ public class SelfHistoryDTO {
         private Long questionListId;
         private String questionListEnterprise;
         private String questionListJob;
+        private String savedLocation;
         private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/witherview/selfPractice/history/SelfHistoryService.java
+++ b/src/main/java/com/witherview/selfPractice/history/SelfHistoryService.java
@@ -1,5 +1,6 @@
 package com.witherview.selfPractice.history;
 
+import com.witherview.account.AccountSession;
 import com.witherview.database.entity.QuestionList;
 import com.witherview.database.entity.SelfHistory;
 import com.witherview.database.entity.User;
@@ -10,9 +11,11 @@ import com.witherview.exception.BusinessException;
 import com.witherview.exception.ErrorCode;
 import com.witherview.selfPractice.exception.NotFoundQuestionList;
 import com.witherview.selfPractice.exception.NotFoundUser;
+import com.witherview.video.VideoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -23,11 +26,12 @@ public class SelfHistoryService {
     private final UserRepository userRepository;
     private final QuestionListRepository questionListRepository;
     private final SelfHistoryRepository selfHistoryRepository;
+    private final VideoService videoService;
 
     @Transactional
-    public SelfHistory save(SelfHistoryDTO.SelfHistorySaveDTO dto, Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
-        QuestionList questionList = questionListRepository.findById(dto.getQuestionListId())
+    public SelfHistory save(MultipartFile videoFile, Long questionListId, AccountSession accountSession) {
+        User user = userRepository.findById(accountSession.getId()).orElseThrow(NotFoundUser::new);
+        QuestionList questionList = questionListRepository.findById(questionListId)
                                     .orElseThrow(NotFoundQuestionList::new);
         if (!user.getId().equals(questionList.getOwner().getId())) {
             throw new BusinessException(ErrorCode.NOT_FOUND_QUESTIONLIST);
@@ -35,7 +39,11 @@ public class SelfHistoryService {
 
         SelfHistory selfHistory = new SelfHistory(questionList);
         user.addSelfHistory(selfHistory);
-        return selfHistoryRepository.save(selfHistory);
+        selfHistoryRepository.save(selfHistory);
+        String savedLocation = videoService.upload(videoFile,
+                                           accountSession.getEmail() + "/self/" + selfHistory.getId());
+        selfHistory.updateSavedLocation(savedLocation);
+        return selfHistory;
     }
 
     public List<SelfHistory> findAll(Long userId) {

--- a/src/main/java/com/witherview/selfPractice/history/SelfHistoryService.java
+++ b/src/main/java/com/witherview/selfPractice/history/SelfHistoryService.java
@@ -34,7 +34,7 @@ public class SelfHistoryService {
         QuestionList questionList = questionListRepository.findById(questionListId)
                                     .orElseThrow(NotFoundQuestionList::new);
         if (!user.getId().equals(questionList.getOwner().getId())) {
-            throw new BusinessException(ErrorCode.NOT_FOUND_QUESTIONLIST);
+            throw new NotFoundQuestionList();
         }
 
         SelfHistory selfHistory = new SelfHistory(questionList);

--- a/src/main/java/com/witherview/video/VideoService.java
+++ b/src/main/java/com/witherview/video/VideoService.java
@@ -22,6 +22,9 @@ public class VideoService {
     @Value("${ffmpeg.path}")
     private String ffmpegPath;
 
+    @Value("${server.url}")
+    private String serverUrl;
+
     public String upload(MultipartFile videoFile, String fileName) {
         String originalVideoPath = uploadLocation + fileName + ".webm";
         String convertedVideoPath = uploadLocation + fileName + ".m3u8";
@@ -31,7 +34,7 @@ public class VideoService {
         try {
             FileUtils.copyInputStreamToFile(videoFile.getInputStream(), newVideoFile);
             convertToHls(originalVideoPath, convertedVideoPath);
-            return convertedVideoPath;
+            return serverUrl + fileName + ".m3u8";
         } catch (Exception e) {
             FileUtils.deleteQuietly(newVideoFile);
             throw new NotSavedVideo();

--- a/src/main/java/com/witherview/video/VideoService.java
+++ b/src/main/java/com/witherview/video/VideoService.java
@@ -1,0 +1,61 @@
+package com.witherview.video;
+
+import com.witherview.video.exception.NotSavedVideo;
+import net.bramp.ffmpeg.FFmpeg;
+import net.bramp.ffmpeg.FFmpegExecutor;
+import net.bramp.ffmpeg.FFprobe;
+import net.bramp.ffmpeg.builder.FFmpegBuilder;
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+@Service
+public class VideoService {
+
+    @Value("${upload.location}")
+    private String uploadLocation;
+
+    @Value("${ffmpeg.path}")
+    private String ffmpegPath;
+
+    public String upload(MultipartFile videoFile, String fileName) {
+        String originalVideoPath = uploadLocation + fileName + ".webm";
+        String convertedVideoPath = uploadLocation + fileName + ".m3u8";
+
+        File newVideoFile = new File(originalVideoPath);
+
+        try {
+            FileUtils.copyInputStreamToFile(videoFile.getInputStream(), newVideoFile);
+            convertToHls(originalVideoPath, convertedVideoPath);
+            return convertedVideoPath;
+        } catch (Exception e) {
+            FileUtils.deleteQuietly(newVideoFile);
+            throw new NotSavedVideo();
+        }
+    }
+
+    private void convertToHls(String inputPath, String outputPath) throws IOException {
+        FFmpeg ffmpeg = new FFmpeg(ffmpegPath+"ffmpeg");		// ffmpeg 파일 경로
+        FFprobe ffprobe = new FFprobe(ffmpegPath+"ffprobe");	// ffprobe 파일 경로
+        FFmpegBuilder builder = new FFmpegBuilder()
+                .setInput(inputPath)
+                .addOutput(outputPath)
+                .addExtraArgs("-c:v", "libx264")
+                .addExtraArgs("-c:a", "copy")
+                .addExtraArgs("-start_number", "0")
+                .addExtraArgs("-hls_list_size", "0")
+                .addExtraArgs("-hls_time", "10")
+                .addExtraArgs("-hls_flags", "omit_endlist")
+                .addExtraArgs("-hls_flags", "delete_segments")
+                .addExtraArgs("-hls_flags", "append_list")
+                .addExtraArgs("-f", "hls")
+                .done();
+
+        FFmpegExecutor executor = new FFmpegExecutor(ffmpeg, ffprobe);
+        executor.createJob(builder).run();
+    }
+}

--- a/src/main/java/com/witherview/video/exception/NotSavedVideo.java
+++ b/src/main/java/com/witherview/video/exception/NotSavedVideo.java
@@ -1,0 +1,10 @@
+package com.witherview.video.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class NotSavedVideo extends BusinessException {
+    public NotSavedVideo() {
+        super(ErrorCode.NOT_SAVED_VIDEO);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,11 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
 
+  servlet:
+    multipart:
+      max-file-size: 1024MB
+      max-request-size: 1024MB
+
   mvc:
     throw-exception-if-no-handler-found: true
   resources:
@@ -55,6 +60,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+
+  servlet:
+    multipart:
+      max-file-size: 1024MB
+      max-request-size: 1024MB
 
   mvc:
     throw-exception-if-no-handler-found: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,12 @@ server:
   port: 8080
   host: localhost
 
+upload:
+  location: /root/videos/
+
+ffmpeg:
+  path: /root/ffmpeg_sources/ffmpeg/
+
 spring:
   datasource:
     username: guest

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 server:
   port: 8080
   host: localhost
+  url: http://localhost:8080/
 
 upload:
   location: /root/videos/


### PR DESCRIPTION
## 추가한 사항
- yml 설정 정보 추가
  - multipart
  - ffmpeg
- 비디오
  - 비디오 저장 후 hls 변환
    - 경로: `/이메일/self/selfHistoryId.m3u8`
- 혼자연습 히스토리 Entity
  - 영상 url 저장할 컬럼 추가
- 리소스
  - 리소스 핸들러 추가
  - 리소스 접근시 검증 로직 인터셉터로 추가

## 수정한 사항
- `/api/**` 경로에 대한 `excludePathPatterns` 삭제
- 혼자연습 등록시 dto 클래스 사용하지 않으므로 삭제