### PR TITLE
그룹 면접 스터디 api 작성 

### DIFF
--- a/src/main/java/com/witherview/database/entity/StudyFeedback.java
+++ b/src/main/java/com/witherview/database/entity/StudyFeedback.java
@@ -28,10 +28,6 @@ public class StudyFeedback extends CreatedBaseEntity {
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
 
-    @NotBlank
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String feedbackMessage;
-
     @NotNull
     private Byte score;
 
@@ -40,10 +36,9 @@ public class StudyFeedback extends CreatedBaseEntity {
 
     @Builder
     public StudyFeedback(StudyRoom studyRoom, User writtenUser,
-                         String feedbackMessage, Byte score, Boolean passOrFail) {
+                         Byte score, Boolean passOrFail) {
         this.studyRoom = studyRoom;
         this.writtenUser = writtenUser;
-        this.feedbackMessage = feedbackMessage;
         this.score = score;
         this.passOrFail = passOrFail;
     }

--- a/src/main/java/com/witherview/database/entity/StudyRoom.java
+++ b/src/main/java/com/witherview/database/entity/StudyRoom.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Entity @Getter
 @NoArgsConstructor
 @Table(name = "tbl_study_room")
-public class StudyRoom extends CreatedBaseEntity {
+public class StudyRoom {
 
     @Id @GeneratedValue
     private Long id;
@@ -30,15 +30,23 @@ public class StudyRoom extends CreatedBaseEntity {
 
     @NotBlank
     @Column(nullable = false)
-    private String describe;
+    private String description;
 
-    @NotNull
-    @Column(nullable = false)
-    private Byte nowUserCnt;
+//    @NotNull
+//    @Column(nullable = false)
+//    private Byte nowUserCnt;
+//
+//    @NotNull
+//    @Column(nullable = false)
+//    private Byte maxUserCnt;
 
-    @NotNull
+    @NotBlank
     @Column(nullable = false)
-    private Byte maxUserCnt;
+    private String industry;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String job;
 
     @Column(columnDefinition = "DATE")
     private LocalDate date;
@@ -53,11 +61,13 @@ public class StudyRoom extends CreatedBaseEntity {
     private List<Chat> chats = new ArrayList<>();
 
     @Builder
-    public StudyRoom(String title, String describe, Byte nowUserCnt, Byte maxUserCnt, LocalDate date, LocalTime time) {
+    public StudyRoom(String title, String description,
+                     String industry, String job,
+                     LocalDate date, LocalTime time) {
         this.title = title;
-        this.describe = describe;
-        this.nowUserCnt = nowUserCnt;
-        this.maxUserCnt = maxUserCnt;
+        this.description = description;
+        this.industry = industry;
+        this.job = job;
         this.date = date;
         this.time = time;
     }
@@ -73,5 +83,16 @@ public class StudyRoom extends CreatedBaseEntity {
 
     public void addParticipants(StudyRoomParticipant studyRoomParticipant) {
         this.studyRoomParticipants.add(studyRoomParticipant);
+    }
+
+    public void update(String title, String description,
+                       String industry, String job,
+                       LocalDate date, LocalTime time) {
+        this.title = title;
+        this.description = description;
+        this.industry = industry;
+        this.job = job;
+        this.date = date;
+        this.time = time;
     }
 }

--- a/src/main/java/com/witherview/database/repository/StudyRoomParticipantRepository.java
+++ b/src/main/java/com/witherview/database/repository/StudyRoomParticipantRepository.java
@@ -4,9 +4,10 @@ import com.witherview.database.entity.StudyRoomParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.LongSummaryStatistics;
 
 public interface StudyRoomParticipantRepository extends JpaRepository<StudyRoomParticipant, Long> {
-    List<StudyRoomParticipant> findByStudyRoomId(Long studyRoomId);
+    StudyRoomParticipant findByStudyRoomIdAndUserId(Long studyRoomId, Long userId);
 
     void deleteByStudyRoomIdAndUserId(Long studyRoomId, Long userId);
 }

--- a/src/main/java/com/witherview/database/repository/StudyRoomParticipantRepository.java
+++ b/src/main/java/com/witherview/database/repository/StudyRoomParticipantRepository.java
@@ -3,5 +3,10 @@ package com.witherview.database.repository;
 import com.witherview.database.entity.StudyRoomParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StudyRoomParticipantRepository extends JpaRepository<StudyRoomParticipant, Long> {
+    List<StudyRoomParticipant> findByStudyRoomId(Long studyRoomId);
+
+    void deleteByStudyRoomIdAndUserId(Long studyRoomId, Long userId);
 }

--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
     NOT_FOUND_QUESTION(404, "SELF-PRACTICE003", "해당 질문이 없습니다."),
 
     // Group-Practice
-    NOT_FOUND_STUDYROOM(404, "GROUP-PRACTICE001", "해당 스터디방이 없습니다.");
+    NOT_FOUND_STUDYROOM(404, "GROUP-PRACTICE001", "해당 스터디방이 없습니다."),
+    ALREADY_JOIN_STUDYROOM(400, "GROUP-PRACTICE001", "이미 참여하고 있는 스터디룸입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
     // Self-Practice
     NOT_FOUND_USER(404, "SELF-PRACTICE001", "해당 유저가 없습니다."),
     NOT_FOUND_QUESTIONLIST(404, "SELF-PRACTICE002", "해당 질문리스트가 없습니다."),
-    NOT_FOUND_QUESTION(404, "SELF-PRACTICE003", "해당 질문이 없습니다.");
+    NOT_FOUND_QUESTION(404, "SELF-PRACTICE003", "해당 질문이 없습니다."),
+
+    // Group-Practice
+    NOT_FOUND_STUDYROOM(404, "GROUP-PRACTICE001", "해당 스터디방이 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -25,7 +25,8 @@ public enum ErrorCode {
 
     // Group-Practice
     NOT_FOUND_STUDYROOM(404, "GROUP-PRACTICE001", "해당 스터디방이 없습니다."),
-    ALREADY_JOIN_STUDYROOM(400, "GROUP-PRACTICE001", "이미 참여하고 있는 스터디룸입니다."),
+    ALREADY_JOIN_STUDYROOM(400, "GROUP-PRACTICE002", "이미 참여하고 있는 스터디룸입니다."),
+    NOT_JOIN_STUDYROOM(400, "GROUP-PRACTICE003", "참여하지 않은 스터디룸입니다."),
 
     // Video
     NOT_SAVED_VIDEO(500, "VIDEO001", "비디오를 저장하는데 실패하였습니다.");

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -1,0 +1,127 @@
+package com.witherview.groupPractice;
+
+import com.witherview.account.AccountDTO;
+import com.witherview.account.AccountSession;
+import com.witherview.database.entity.StudyFeedback;
+import com.witherview.database.entity.StudyRoom;
+import com.witherview.database.entity.User;
+import com.witherview.exception.ErrorCode;
+import com.witherview.exception.ErrorResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+import java.util.List;
+
+@Api(tags = "GroupStudy API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/group")
+public class GroupStudyController {
+    private final ModelMapper modelMapper;
+    private final GroupStudyService groupStudyService;
+
+    @ApiOperation(value="스터디방 생성")
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> createStudy(@RequestBody @Valid GroupStudyDTO.StudyCreateDTO requestDto,
+                                         BindingResult result,
+                                         @ApiIgnore HttpSession session) {
+        if(result.hasErrors()) {
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        }
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        StudyRoom studyRoom = groupStudyService.saveRoom(accountSession.getId(), requestDto);
+
+        // 스터디방 생성자도 방 참여자로 등록
+        groupStudyService.joinRoom(studyRoom.getId(), accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(studyRoom, GroupStudyDTO.ResponseDTO.class), HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value="스터디방 수정")
+    @PatchMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> updateQuestion(@RequestBody @Valid GroupStudyDTO.StudyUpdateDTO requestDto,
+                                            BindingResult result) {
+
+        if(result.hasErrors()) {
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        }
+
+        groupStudyService.updateRoom(requestDto);
+        StudyRoom studyRoom = groupStudyService.findRoom(requestDto.getId());
+        return new ResponseEntity<>(modelMapper.map(studyRoom, GroupStudyDTO.ResponseDTO.class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="스터디방 조회")
+    @GetMapping
+    public ResponseEntity<?> findAllRooms() {
+        List<StudyRoom> lists = groupStudyService.findAllRooms();
+        return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ResponseDTO[].class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="특정 유저가 참여한 스터디방 조회")
+    @GetMapping(path = "/participation")
+    public ResponseEntity<?> findParticipatedRooms(@ApiIgnore HttpSession session) {
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        List<StudyRoom> lists = groupStudyService.findParticipatedRooms(accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ResponseDTO[].class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="스터디방 삭제")
+    @DeleteMapping(path = "/{id}")
+    public ResponseEntity<?> deleteRoom(@ApiParam(value = "삭제할 질문 id", required = true) @PathVariable Long id) {
+        StudyRoom deletedRoom = groupStudyService.deleteRoom(id);
+        return new ResponseEntity<>(modelMapper.map(deletedRoom, GroupStudyDTO.DeleteResponseDTO.class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="스터디방 참여")
+    @PostMapping(path = "/room/{id}")
+    public ResponseEntity<?> joinRoom(@ApiParam(value = "참여할 방 id", required = true) @PathVariable Long id,
+                                      @ApiIgnore HttpSession session) {
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        StudyRoom studyRoom = groupStudyService.joinRoom(id, accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(studyRoom, GroupStudyDTO.ResponseDTO.class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="해당 스터디방 참여자 조회")
+    @GetMapping(path = "/room/{id}")
+    public ResponseEntity<?> findParticipants(@ApiParam(value = "참여할 방 id", required = true) @PathVariable Long id) {
+        List<User> lists = groupStudyService.findParticipants(id);
+        return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ParticipantDTO[].class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="스터디방 나가기")
+    @DeleteMapping(path = "/room/{id}")
+    public ResponseEntity<?> leaveRoom(@ApiParam(value = "나갈 방 id", required = true) @PathVariable Long id,
+                                       @ApiIgnore HttpSession session) {
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        StudyRoom leftRoom = groupStudyService.leaveRoom(id, accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(leftRoom, GroupStudyDTO.DeleteResponseDTO.class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="스터디 피드백")
+    @PostMapping(path = "/feedback", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> feedback(@RequestBody @Valid GroupStudyDTO.StudyFeedBackDTO requestDto,
+                                      BindingResult result,
+                                      @ApiIgnore HttpSession session) {
+        if(result.hasErrors()) {
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        }
+
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        StudyFeedback studyFeedback = groupStudyService.createFeedBack(accountSession.getId(), requestDto);
+        return new ResponseEntity<>(modelMapper.map(studyFeedback, GroupStudyDTO.FeedBackResponseDTO.class), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -79,7 +79,7 @@ public class GroupStudyController {
 
     @ApiOperation(value="스터디방 삭제")
     @DeleteMapping(path = "/{id}")
-    public ResponseEntity<?> deleteRoom(@ApiParam(value = "삭제할 질문 id", required = true) @PathVariable Long id) {
+    public ResponseEntity<?> deleteRoom(@ApiParam(value = "삭제할 방 id", required = true) @PathVariable Long id) {
         StudyRoom deletedRoom = groupStudyService.deleteRoom(id);
         return new ResponseEntity<>(modelMapper.map(deletedRoom, GroupStudyDTO.DeleteResponseDTO.class), HttpStatus.OK);
     }
@@ -101,7 +101,7 @@ public class GroupStudyController {
 
     @ApiOperation(value="해당 스터디방 참여자 조회")
     @GetMapping(path = "/room/{id}")
-    public ResponseEntity<?> findParticipants(@ApiParam(value = "참여할 방 id", required = true) @PathVariable Long id) {
+    public ResponseEntity<?> findParticipants(@ApiParam(value = "참여 조회할 방 id", required = true) @PathVariable Long id) {
         List<User> lists = groupStudyService.findParticipatedUsers(id);
         return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ParticipantDTO[].class), HttpStatus.OK);
     }

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -127,6 +127,6 @@ public class GroupStudyController {
 
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
         StudyFeedback studyFeedback = groupStudyService.createFeedBack(accountSession.getId(), requestDto);
-        return new ResponseEntity<>(modelMapper.map(studyFeedback, GroupStudyDTO.FeedBackResponseDTO.class), HttpStatus.OK);
+        return new ResponseEntity<>(modelMapper.map(studyFeedback, GroupStudyDTO.FeedBackResponseDTO.class), HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -1,6 +1,5 @@
 package com.witherview.groupPractice;
 
-import com.witherview.account.AccountDTO;
 import com.witherview.account.AccountSession;
 import com.witherview.database.entity.StudyFeedback;
 import com.witherview.database.entity.StudyRoom;
@@ -86,18 +85,24 @@ public class GroupStudyController {
     }
 
     @ApiOperation(value="스터디방 참여")
-    @PostMapping(path = "/room/{id}")
-    public ResponseEntity<?> joinRoom(@ApiParam(value = "참여할 방 id", required = true) @PathVariable Long id,
+    @PostMapping(path = "/room", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> joinRoom(@RequestBody @Valid GroupStudyDTO.StudyJoinDTO requestDto,
+                                      BindingResult result,
                                       @ApiIgnore HttpSession session) {
+        if(result.hasErrors()) {
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        }
+
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
-        StudyRoom studyRoom = groupStudyService.joinRoom(id, accountSession.getId());
+        StudyRoom studyRoom = groupStudyService.joinRoom(requestDto.getId(), accountSession.getId());
         return new ResponseEntity<>(modelMapper.map(studyRoom, GroupStudyDTO.ResponseDTO.class), HttpStatus.OK);
     }
 
     @ApiOperation(value="해당 스터디방 참여자 조회")
     @GetMapping(path = "/room/{id}")
     public ResponseEntity<?> findParticipants(@ApiParam(value = "참여할 방 id", required = true) @PathVariable Long id) {
-        List<User> lists = groupStudyService.findParticipants(id);
+        List<User> lists = groupStudyService.findParticipatedUsers(id);
         return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ParticipantDTO[].class), HttpStatus.OK);
     }
 

--- a/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
@@ -1,0 +1,108 @@
+package com.witherview.groupPractice;
+
+import com.witherview.database.entity.StudyRoom;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class GroupStudyDTO {
+    @Getter @Setter @Builder
+    public static class StudyCreateDTO {
+        @NotBlank(message = "방 제목은 반드시 입력해야 합니다.")
+        private String title;
+
+        @NotBlank(message = "방 설명은 반드시 입력해야 합니다.")
+        private String description;
+
+        @NotBlank(message = "산업 이름은 반드시 입력해야 합니다.")
+        private String industry;
+
+        @NotBlank(message = "직무 이름은 반드시 입력해야 합니다.")
+        private String job;
+
+        private LocalDate date;
+        private LocalTime time;
+
+        public StudyRoom toEntity() {
+            return StudyRoom.builder()
+                    .title(title)
+                    .description(description)
+                    .industry(industry)
+                    .job(job)
+                    .date(date)
+                    .time(time)
+                    .build();
+        }
+    }
+
+    @Getter @Setter
+    public static class StudyUpdateDTO {
+        @NotNull(message = "방 아이디는 반드시 입력해야 합니다.")
+        private Long id;
+
+        @NotBlank(message = "방 제목은 반드시 입력해야 합니다.")
+        private String title;
+
+        @NotBlank(message = "방 설명은 반드시 입력해야 합니다.")
+        private String description;
+
+        @NotBlank(message = "산업 이름은 반드시 입력해야 합니다.")
+        private String industry;
+
+        @NotBlank(message = "직무 이름은 반드시 입력해야 합니다.")
+        private String job;
+
+        private LocalDate date;
+        private LocalTime time;
+    }
+
+    @Getter @Setter
+    public static class StudyFeedBackDTO {
+        @NotNull(message = "방 아이디는 반드시 입력해야 합니다.")
+        private Long id;
+
+        @NotNull(message = "타겟 유저id는 반드시 입력해야 합니다.")
+        private Long targetUser;
+
+        @NotNull(message = "점수는 반드시 입력해야 합니다.")
+        private Byte score;
+
+        @NotNull(message = "합격 여부는 반드시 입력해야 합니다.")
+        private Boolean passOrFail;
+    }
+
+    @Getter @Setter
+    public static class ResponseDTO {
+        private Long id;
+        private String title;
+        private String description;
+        private String industry;
+        private String job;
+        private LocalDate date;
+        private LocalTime time;
+    }
+
+    @Getter @Setter
+    public static class ParticipantDTO {
+        private String email;
+        private String name;
+    }
+
+    @Getter @Setter
+    public static class FeedBackResponseDTO {
+        private Long id;
+        private Long targetUserId;
+        private Byte score;
+        private Boolean passOrFail;
+    }
+
+    @Getter @Setter
+    public static class DeleteResponseDTO {
+        private Long id;
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
@@ -66,7 +66,7 @@ public class GroupStudyDTO {
         @NotNull(message = "방 아이디는 반드시 입력해야 합니다.")
         private Long id;
 
-        @NotNull(message = "타겟 유저id는 반드시 입력해야 합니다.")
+        @NotNull(message = "타겟 유저아이디는 반드시 입력해야 합니다.")
         private Long targetUser;
 
         @NotNull(message = "점수는 반드시 입력해야 합니다.")

--- a/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
@@ -40,7 +40,7 @@ public class GroupStudyDTO {
         }
     }
 
-    @Getter @Setter
+    @Getter @Setter @Builder
     public static class StudyUpdateDTO {
         @NotNull(message = "방 아이디는 반드시 입력해야 합니다.")
         private Long id;
@@ -61,7 +61,7 @@ public class GroupStudyDTO {
         private LocalTime time;
     }
 
-    @Getter @Setter
+    @Getter @Setter @Builder
     public static class StudyFeedBackDTO {
         @NotNull(message = "방 아이디는 반드시 입력해야 합니다.")
         private Long id;
@@ -74,6 +74,12 @@ public class GroupStudyDTO {
 
         @NotNull(message = "합격 여부는 반드시 입력해야 합니다.")
         private Boolean passOrFail;
+    }
+
+    @Getter @Setter
+    public static class StudyJoinDTO {
+        @NotNull(message = "방 아이디는 반드시 입력해야 합니다.")
+        private Long id;
     }
 
     @Getter @Setter

--- a/src/main/java/com/witherview/groupPractice/GroupStudyService.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyService.java
@@ -1,0 +1,130 @@
+package com.witherview.groupPractice;
+
+import com.witherview.database.entity.StudyFeedback;
+import com.witherview.database.entity.StudyRoom;
+import com.witherview.database.entity.StudyRoomParticipant;
+import com.witherview.database.entity.User;
+import com.witherview.database.repository.StudyFeedbackRepository;
+import com.witherview.database.repository.StudyRoomParticipantRepository;
+import com.witherview.database.repository.StudyRoomRepository;
+import com.witherview.database.repository.UserRepository;
+import com.witherview.groupPractice.exception.NotFoundStudyRoom;
+import com.witherview.selfPractice.exception.NotFoundUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class GroupStudyService {
+
+    private final StudyRoomRepository studyRoomRepository;
+    private final StudyFeedbackRepository studyFeedbackRepository;
+    private final StudyRoomParticipantRepository studyRoomParticipantRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public StudyRoom saveRoom(Long userId, GroupStudyDTO.StudyCreateDTO requestDto) {
+        StudyRoom studyRoom = requestDto.toEntity();
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
+
+        user.addHostedRoom(studyRoom);
+
+        return studyRoomRepository.save(studyRoom);
+    }
+
+    @Transactional
+    public void updateRoom(GroupStudyDTO.StudyUpdateDTO requestDto) {
+        StudyRoom studyRoom = findRoom(requestDto.getId());
+        studyRoom.update(requestDto.getTitle(), requestDto.getDescription(),
+                        requestDto.getIndustry(), requestDto.getJob(),
+                        requestDto.getDate(), requestDto.getTime());
+    }
+
+    @Transactional
+    public StudyRoom deleteRoom(Long id) {
+        StudyRoom studyRoom = findRoom(id);
+        studyRoomRepository.delete(studyRoom);
+        return studyRoom;
+    }
+
+    @Transactional
+    public StudyRoom joinRoom(Long id, Long userId) {
+        StudyRoom studyRoom = findRoom(id);
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
+        StudyRoomParticipant studyRoomParticipant = StudyRoomParticipant.builder()
+                                                                        .studyRoom(studyRoom)
+                                                                        .user(user)
+                                                                        .build();
+
+        studyRoom.addParticipants(studyRoomParticipant);
+        user.addParticipatedRoom(studyRoomParticipant);
+        return studyRoom;
+    }
+
+    @Transactional
+    public StudyRoom leaveRoom(Long id, Long userId) {
+        StudyRoom studyRoom = findRoom(id);
+        studyRoomParticipantRepository.deleteByStudyRoomIdAndUserId(id, userId);
+        return studyRoom;
+    }
+
+    @Transactional
+    public StudyFeedback createFeedBack(Long userId, GroupStudyDTO.StudyFeedBackDTO requestDto) {
+        StudyRoom studyRoom = findRoom(requestDto.getId());
+        User writtenUser = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
+        User targetUser = userRepository.findById(requestDto.getTargetUser()).orElseThrow(NotFoundUser::new);
+
+        StudyFeedback studyFeedback = StudyFeedback.builder()
+                                                    .studyRoom(studyRoom)
+                                                    .writtenUser(writtenUser)
+                                                    .score(requestDto.getScore())
+                                                    .passOrFail(requestDto.getPassOrFail())
+                                                    .build();
+
+        targetUser.addStudyFeedback(studyFeedback);
+
+        return studyFeedbackRepository.save(studyFeedback);
+    }
+
+    public List<User> findParticipants(Long id) {
+        return findRoom(id).getStudyRoomParticipants()
+                            .stream()
+                            .map(r -> r.getUser())
+                            .collect(Collectors.toList());
+    }
+
+    public StudyRoom findRoom(Long id) {
+        return studyRoomRepository.findById(id)
+                .orElseThrow(NotFoundStudyRoom::new);
+    }
+
+    public List<StudyRoom> findParticipatedRooms(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
+        return user.getParticipatedStudyRooms()
+                    .stream()
+                    .map(r -> r.getStudyRoom())
+                    .collect(Collectors.toList());
+    }
+
+    public List<StudyRoom> findAllRooms() {
+        List<StudyRoom> lists = studyRoomRepository.findAll();
+        // 면접 날짜 가까운 순으로 정렬
+        Collections.sort(lists, new Comparator<StudyRoom>() {
+            @Override
+            public int compare(StudyRoom o1, StudyRoom o2) {
+                if(o1.getDate().isEqual(o2.getDate())) {
+                    return o2.getTime().isBefore(o1.getTime()) ? 1 : -1;
+                }
+                return o2.getDate().isBefore(o1.getDate()) ? 1 : -1;
+            }
+        });
+        return lists;
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/GroupStudyService.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyService.java
@@ -10,6 +10,7 @@ import com.witherview.database.repository.StudyRoomRepository;
 import com.witherview.database.repository.UserRepository;
 import com.witherview.groupPractice.exception.AlreadyJoinedStudyRoom;
 import com.witherview.groupPractice.exception.NotFoundStudyRoom;
+import com.witherview.groupPractice.exception.NotJoinedStudyRoom;
 import com.witherview.selfPractice.exception.NotFoundUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -38,7 +39,6 @@ public class GroupStudyService {
         User user = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
 
         user.addHostedRoom(studyRoom);
-
         return studyRoomRepository.save(studyRoom);
     }
 
@@ -72,11 +72,16 @@ public class GroupStudyService {
                                                                         .build();
         studyRoom.addParticipants(studyRoomParticipant);
         user.addParticipatedRoom(studyRoomParticipant);
+        studyRoomParticipantRepository.save(studyRoomParticipant);
         return studyRoom;
     }
 
     @Transactional
     public StudyRoom leaveRoom(Long id, Long userId) {
+        // 참여하지 않은 방인 경우
+        if(findParticipant(id, userId) == null) {
+            throw new NotJoinedStudyRoom();
+        }
         StudyRoom studyRoom = findRoom(id);
         studyRoomParticipantRepository.deleteByStudyRoomIdAndUserId(id, userId);
         return studyRoom;
@@ -96,7 +101,6 @@ public class GroupStudyService {
                                                     .build();
 
         targetUser.addStudyFeedback(studyFeedback);
-
         return studyFeedbackRepository.save(studyFeedback);
     }
 

--- a/src/main/java/com/witherview/groupPractice/exception/AlreadyJoinedStudyRoom.java
+++ b/src/main/java/com/witherview/groupPractice/exception/AlreadyJoinedStudyRoom.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class AlreadyJoinedStudyRoom extends BusinessException {
+    public AlreadyJoinedStudyRoom() {
+        super(ErrorCode.ALREADY_JOIN_STUDYROOM);
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/exception/NotFoundStudyRoom.java
+++ b/src/main/java/com/witherview/groupPractice/exception/NotFoundStudyRoom.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class NotFoundStudyRoom extends BusinessException {
+    public NotFoundStudyRoom() {
+        super(ErrorCode.NOT_FOUND_STUDYROOM);
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/exception/NotJoinedStudyRoom.java
+++ b/src/main/java/com/witherview/groupPractice/exception/NotJoinedStudyRoom.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class NotJoinedStudyRoom extends BusinessException {
+    public NotJoinedStudyRoom() {
+        super(ErrorCode.NOT_JOIN_STUDYROOM);
+    }
+}

--- a/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
@@ -12,8 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -185,6 +184,16 @@ public class GroupStudyApiTest extends GroupStudySupporter {
                 .andExpect(status().isBadRequest());
 
         resultActions.andExpect(jsonPath("$.message").value("이미 참여하고 있는 스터디룸입니다."));
+        resultActions.andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    public void 스터디룸_나가기_실패_참여하고있지_않은_스터디룸() throws Exception {
+        ResultActions resultActions = mockMvc.perform(delete("/api/group/room/" + roomId)
+                .session(mockHttpSession))
+                .andExpect(status().isBadRequest());
+
+        resultActions.andExpect(jsonPath("$.message").value("참여하지 않은 스터디룸입니다."));
         resultActions.andExpect(jsonPath("$.status").value(400));
     }
 }

--- a/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
@@ -1,0 +1,190 @@
+package com.witherview.groupPractice;
+
+import com.witherview.database.entity.StudyRoom;
+import com.witherview.database.entity.StudyRoomParticipant;
+import com.witherview.database.entity.User;
+import com.witherview.database.repository.StudyRoomRepository;
+import com.witherview.groupPractice.exception.NotFoundStudyRoom;
+import com.witherview.selfPractice.exception.NotFoundUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+public class GroupStudyApiTest extends GroupStudySupporter {
+
+    @Autowired
+    StudyRoomRepository studyRoomRepository;
+
+    @Test
+    public void 스터디룸_등록성공() throws Exception {
+        GroupStudyDTO.StudyCreateDTO dto = GroupStudyDTO.StudyCreateDTO.builder()
+                .title(title2)
+                .description(description2)
+                .industry(industry1)
+                .job(job1)
+                .date(date2)
+                .time(time2)
+                .build();
+
+        ResultActions resultActions = mockMvc.perform(post("/api/group")
+                .session(mockHttpSession)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print())
+                .andExpect(status().isCreated());
+
+        resultActions.andExpect(jsonPath("$.title").value(title2));
+        resultActions.andExpect(jsonPath("$.description").value(description2));
+        resultActions.andExpect(jsonPath("$.industry").value(industry1));
+        resultActions.andExpect(jsonPath("$.job").value(job1));
+        resultActions.andExpect(jsonPath("$.date").value(date2.toString()));
+        resultActions.andExpect(jsonPath("$.time").value(time2.toString()));
+    }
+
+    @Test
+    public void 스터디룸_수정성공() throws Exception {
+        GroupStudyDTO.StudyUpdateDTO dto = GroupStudyDTO.StudyUpdateDTO.builder()
+                .id(roomId)
+                .title(updatedTitle)
+                .description(updatedDescription)
+                .industry(industry1)
+                .job(job1)
+                .date(date1)
+                .time(time1)
+                .build();
+
+        ResultActions resultActions = mockMvc.perform(patch("/api/group")
+                .session(mockHttpSession)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(jsonPath("$.title").value(updatedTitle));
+        resultActions.andExpect(jsonPath("$.description").value(updatedDescription));
+    }
+
+    @Test
+    public void 스터디_피드백_등록_성공() throws Exception {
+        GroupStudyDTO.StudyFeedBackDTO dto = GroupStudyDTO.StudyFeedBackDTO.builder()
+                .id(roomId)
+                .targetUser(userId2)
+                .score(score)
+                .passOrFail(passOrFail)
+                .build();
+
+        ResultActions resultActions = mockMvc.perform(post("/api/group/feedback")
+                .session(mockHttpSession)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(jsonPath("$.targetUserId").value(userId2));
+        resultActions.andExpect(jsonPath("$.score").value(score.intValue()));
+        resultActions.andExpect(jsonPath("$.passOrFail").value(passOrFail));
+    }
+
+    @Test
+    public void 스터디방_참여_성공() throws Exception {
+        GroupStudyDTO.StudyJoinDTO dto = new GroupStudyDTO.StudyJoinDTO();
+        dto.setId(roomId);
+
+        ResultActions resultActions = mockMvc.perform(post("/api/group/room")
+                .session(mockHttpSession)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(jsonPath("$.title").value(title1));
+        resultActions.andExpect(jsonPath("$.description").value(description1));
+        resultActions.andExpect(jsonPath("$.industry").value(industry1));
+        resultActions.andExpect(jsonPath("$.job").value(job1));
+        resultActions.andExpect(jsonPath("$.date").value(date1.toString()));
+        resultActions.andExpect(jsonPath("$.time").value(time1.toString()));
+    }
+
+    @Test
+    public void 스터디룸_등록실패_유효하지_않은_사용자() throws Exception {
+        GroupStudyDTO.StudyCreateDTO dto = GroupStudyDTO.StudyCreateDTO.builder()
+                .title(title2)
+                .description(description2)
+                .industry(industry1)
+                .job(job1)
+                .date(date2)
+                .time(time2)
+                .build();
+
+        ResultActions resultActions = mockMvc.perform(post("/api/group")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+
+        resultActions.andExpect(jsonPath("$.message").value("로그인 후 이용해 주세요."));
+        resultActions.andExpect(jsonPath("$.status").value(401));
+    }
+
+    @Test
+    public void 스터디_피드백_등록_실패_존재하지_않는_스터디룸() throws Exception {
+        GroupStudyDTO.StudyFeedBackDTO dto = GroupStudyDTO.StudyFeedBackDTO.builder()
+                .id((long) 400)
+                .targetUser(userId2)
+                .score(score)
+                .passOrFail(passOrFail)
+                .build();
+
+        ResultActions resultActions = mockMvc.perform(post("/api/group/feedback")
+                .session(mockHttpSession)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+
+        resultActions.andExpect(jsonPath("$.message").value("해당 스터디방이 없습니다."));
+        resultActions.andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    public void 스터디룸_참여_실패_이미_참여하고있는_스터디룸() throws Exception {
+        StudyRoom studyRoom = studyRoomRepository.findById(roomId).orElseThrow(NotFoundStudyRoom::new);
+        User user = userRepository.findById(userId1).orElseThrow(NotFoundUser::new);
+        StudyRoomParticipant studyRoomParticipant = StudyRoomParticipant.builder()
+                .studyRoom(studyRoom)
+                .user(user)
+                .build();
+
+        studyRoom.addParticipants(studyRoomParticipant);
+        user.addParticipatedRoom(studyRoomParticipant);
+
+        GroupStudyDTO.StudyJoinDTO dto = new GroupStudyDTO.StudyJoinDTO();
+        dto.setId(roomId);
+
+        ResultActions resultActions = mockMvc.perform(post("/api/group/room")
+                .session(mockHttpSession)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+        resultActions.andExpect(jsonPath("$.message").value("이미 참여하고 있는 스터디룸입니다."));
+        resultActions.andExpect(jsonPath("$.status").value(400));
+    }
+}

--- a/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
@@ -1,0 +1,71 @@
+package com.witherview.groupPractice;
+
+import com.witherview.account.AccountSession;
+import com.witherview.database.entity.StudyRoom;
+import com.witherview.database.entity.User;
+import com.witherview.database.repository.StudyRoomRepository;
+import com.witherview.database.repository.UserRepository;
+import com.witherview.support.MockMvcSupporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Transactional
+public class GroupStudySupporter extends MockMvcSupporter {
+    final String email1 = "hohoho@witherview.com";
+    final String password1 = "123456";
+    final String name1 = "witherview";
+    final String email2 = "yayaya@witherview.com";
+    final String password2 = "123456";
+    final String name2 = "yapp";
+    final String title1 = "네이버 빅데이터 플랫폼 스터디 모집합니다.";
+    final String description1 =  "코딩테스트 합격자만 신청바랍니다!!!!";
+    final String industry1 = "it서비스";
+    final String job1 = "개발자";
+    final LocalDate date1 = LocalDate.parse("2020-12-03");
+    final LocalTime time1 = LocalTime.parse("15:00:01");
+    final String title2 = "카카오 백엔드 스터디 모집합니다.";
+    final String description2 =  "같이 면접 준비 하실 분 구합니다~~~";
+    final LocalDate date2 = LocalDate.parse("2020-12-04");
+    final LocalTime time2 = LocalTime.parse("12:00:01");
+    final String updatedTitle = "카카오 백엔드 스터디 모집합니다.";
+    final String updatedDescription = "함께 스터디 하실 분 들어요세요";
+    final Byte score = 80;
+    final Boolean passOrFail = true;
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+    Long userId1 = (long)1;
+    Long userId2 = (long)2;
+    Long roomId = (long) 3;
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    StudyRoomRepository studyRoomRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    public void 회원가입_세션생성_스터디룸생성() {
+        // 회원가입
+        User user1 = userRepository.save(new User(email1, passwordEncoder.encode(password1), name1));
+        userId1 = user1.getId();
+
+        User user2 = userRepository.save(new User(email2, passwordEncoder.encode(password2), name2));
+        userId2 = user2.getId();
+
+        // 세션생성
+        AccountSession accountSession = new AccountSession(userId1, email1, name1);
+        mockHttpSession.setAttribute("user", accountSession);
+
+        // 스터디룸생성
+        StudyRoom studyRoom = new StudyRoom(title1, description1, industry1, job1, date1, time1);
+        user1.addHostedRoom(studyRoom);
+        roomId = studyRoomRepository.save(studyRoom).getId();
+    }
+}


### PR DESCRIPTION
## 추가한 사항
- 스터디방 생성 / 조회 / 수정 / 삭제 api
- 스터디방 참여 / 나가기 api
- 스터디 피드백 api
- 특정 유저가 참여한 스터디방 조회 api
- 특정 스터디룸에 참여하고 있는 유저 조회 api

## 수정 사항
- StudyRoom entity 에서 칼럼명 수정 및 최대/최소 인원수 칼럼 삭제(임시)
- StudyFeedback entity 에서 피드백메세지 칼럼 삭제(채팅으로 저장 예정..?)

## 아직 구현하지 못한 부분 
- 현재 특정 스터디방에 몇명 참가하고 있는지 체킹
- 스터디방 리스트 조회 시 특정 개수(6-12개?)씩 조회되도록 & 스크롤 페이징 처리되도록 구현 예정 
- 채팅 구현 예정

> api 가 좀 많아서 파일 하나하나가 엄청 길어졌네요...ㅎㅎ😂
> 재호님 보시고 혹시 더 필요한 부분있으면 말씀해주세요! 