### PR TITLE
면접스터디 조회 시 페이징 처리 및 특정 스터디방 조회 api 추가 / 스터디방 참여자 변경 로직 추가 

### DIFF
--- a/src/main/java/com/witherview/database/entity/StudyRoom.java
+++ b/src/main/java/com/witherview/database/entity/StudyRoom.java
@@ -1,11 +1,15 @@
 package com.witherview.database.entity;
 
+import com.witherview.groupPractice.exception.AlreadyFullStudyRoom;
+import com.witherview.groupPractice.exception.EmptyStudyRoom;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -31,18 +35,18 @@ public class StudyRoom {
     @Column(nullable = false)
     private String description;
 
-//    @NotNull
-//    @Column(nullable = false)
-//    private Byte nowUserCnt;
-//
-//    @NotNull
-//    @Column(nullable = false)
-//    private Byte maxUserCnt;
+    @NotNull
+    @Column(nullable = false)
+    private Integer nowUserCnt;
 
-    @Column(columnDefinition = "varchar(50) default '무관'")
+    @NotNull
+    @Column(nullable = false)
+    private Integer maxUserCnt;
+
+    @ColumnDefault("'무관'")
     private String industry;
 
-    @Column(columnDefinition = "varchar(50) default '무관'")
+    @ColumnDefault("'무관'")
     private String job;
 
     @Column(columnDefinition = "DATE")
@@ -67,6 +71,8 @@ public class StudyRoom {
         this.job = job;
         this.date = date;
         this.time = time;
+        this.nowUserCnt = 0;
+        this.maxUserCnt = 2;
     }
 
     protected void updateHost(User host) {
@@ -91,5 +97,15 @@ public class StudyRoom {
         this.job = job;
         this.date = date;
         this.time = time;
+    }
+
+    public void increaseNowUserCnt() {
+        if(this.nowUserCnt + 1 > this.maxUserCnt) throw new AlreadyFullStudyRoom();
+        this.nowUserCnt++;
+    }
+
+    public void decreaseNowUserCnt() {
+        if(this.nowUserCnt - 1 <= 0) throw new EmptyStudyRoom();
+        this.nowUserCnt--;
     }
 }

--- a/src/main/java/com/witherview/database/entity/StudyRoom.java
+++ b/src/main/java/com/witherview/database/entity/StudyRoom.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -40,12 +39,10 @@ public class StudyRoom {
 //    @Column(nullable = false)
 //    private Byte maxUserCnt;
 
-    @NotBlank
-    @Column(nullable = false)
+    @Column(columnDefinition = "varchar(50) default '무관'")
     private String industry;
 
-    @NotBlank
-    @Column(nullable = false)
+    @Column(columnDefinition = "varchar(50) default '무관'")
     private String job;
 
     @Column(columnDefinition = "DATE")

--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -24,9 +24,11 @@ public enum ErrorCode {
     NOT_FOUND_QUESTION(404, "SELF-PRACTICE003", "해당 질문이 없습니다."),
 
     // Group-Practice
-    NOT_FOUND_STUDYROOM(404, "GROUP-PRACTICE001", "해당 스터디방이 없습니다."),
+    NOT_FOUND_STUDYROOM(404, "GROUP-PRACTICE001", "해당 스터디룸이 없습니다."),
     ALREADY_JOIN_STUDYROOM(400, "GROUP-PRACTICE002", "이미 참여하고 있는 스터디룸입니다."),
     NOT_JOIN_STUDYROOM(400, "GROUP-PRACTICE003", "참여하지 않은 스터디룸입니다."),
+    ALREADY_FULL_STUDYROOM(400, "GROUP-PRACTICE004", "이미 스터디룸이 꽉 차 있습니다."),
+    EMPTY_STUDYROOM(400, "GROUP-PRACTICE005", "스터디룸에 참여자가 없으면 안됩니다."),
 
     // Video
     NOT_SAVED_VIDEO(500, "VIDEO001", "비디오를 저장하는데 실패하였습니다.");

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -64,8 +64,8 @@ public class GroupStudyController {
 
     @ApiOperation(value="스터디방 조회")
     @GetMapping
-    public ResponseEntity<?> findAllRooms() {
-        List<StudyRoom> lists = groupStudyService.findAllRooms();
+    public ResponseEntity<?> findAllRooms(@RequestParam("page") Integer current) {
+        List<StudyRoom> lists = groupStudyService.findRooms(current);
         return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ResponseDTO[].class), HttpStatus.OK);
     }
 

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -64,9 +64,17 @@ public class GroupStudyController {
 
     @ApiOperation(value="스터디방 조회")
     @GetMapping
-    public ResponseEntity<?> findAllRooms(@RequestParam("page") Integer current) {
+    public ResponseEntity<?> findAllRooms(@ApiParam(value = "조회할 page (디폴트 값 = 0)")
+                                              @RequestParam(value = "page", required = false) Integer current) {
         List<StudyRoom> lists = groupStudyService.findRooms(current);
         return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ResponseDTO[].class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="특정 스터디방 조회")
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findSpecificRoom(@ApiParam(value = "조회할 방 id") @PathVariable Long id) {
+        StudyRoom studyRoom = groupStudyService.findRoom(id);
+        return new ResponseEntity<>(modelMapper.map(studyRoom, GroupStudyDTO.ResponseDTO.class), HttpStatus.OK);
     }
 
     @ApiOperation(value="특정 유저가 참여한 스터디방 조회")

--- a/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
@@ -90,6 +90,8 @@ public class GroupStudyDTO {
         private String job;
         private LocalDate date;
         private LocalTime time;
+        private Integer nowUserCnt;
+        private Integer maxUserCnt;
     }
 
     @Getter @Setter

--- a/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
@@ -4,6 +4,7 @@ import com.witherview.database.entity.StudyRoom;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -14,15 +15,16 @@ public class GroupStudyDTO {
     @Getter @Setter @Builder
     public static class StudyCreateDTO {
         @NotBlank(message = "방 제목은 반드시 입력해야 합니다.")
+        @Length(min = 1, message = "방 제목은 1자 이상이어야 합니다.")
+        @Length(max = 20, message = "방 제목은 20자 이하여야 합니다.")
         private String title;
 
         @NotBlank(message = "방 설명은 반드시 입력해야 합니다.")
+        @Length(min = 1, message = "방 설명은 1자 이상이어야 합니다.")
+        @Length(max = 100, message = "방 설명은 100자 이하여야 합니다.")
         private String description;
 
-        @NotBlank(message = "산업 이름은 반드시 입력해야 합니다.")
         private String industry;
-
-        @NotBlank(message = "직무 이름은 반드시 입력해야 합니다.")
         private String job;
 
         private LocalDate date;
@@ -51,10 +53,7 @@ public class GroupStudyDTO {
         @NotBlank(message = "방 설명은 반드시 입력해야 합니다.")
         private String description;
 
-        @NotBlank(message = "산업 이름은 반드시 입력해야 합니다.")
         private String industry;
-
-        @NotBlank(message = "직무 이름은 반드시 입력해야 합니다.")
         private String job;
 
         private LocalDate date;

--- a/src/main/java/com/witherview/groupPractice/GroupStudyService.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyService.java
@@ -71,6 +71,7 @@ public class GroupStudyService {
                                                                         .user(user)
                                                                         .build();
         studyRoom.addParticipants(studyRoomParticipant);
+        studyRoom.increaseNowUserCnt();
         user.addParticipatedRoom(studyRoomParticipant);
         studyRoomParticipantRepository.save(studyRoomParticipant);
         return studyRoom;
@@ -83,6 +84,7 @@ public class GroupStudyService {
             throw new NotJoinedStudyRoom();
         }
         StudyRoom studyRoom = findRoom(id);
+        studyRoom.decreaseNowUserCnt();
         studyRoomParticipantRepository.deleteByStudyRoomIdAndUserId(id, userId);
         return studyRoom;
     }

--- a/src/main/java/com/witherview/groupPractice/GroupStudyService.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyService.java
@@ -13,13 +13,12 @@ import com.witherview.groupPractice.exception.NotFoundStudyRoom;
 import com.witherview.groupPractice.exception.NotJoinedStudyRoom;
 import com.witherview.selfPractice.exception.NotFoundUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,6 +31,7 @@ public class GroupStudyService {
     private final StudyFeedbackRepository studyFeedbackRepository;
     private final StudyRoomParticipantRepository studyRoomParticipantRepository;
     private final UserRepository userRepository;
+    private final int pageSize = 6;
 
     @Transactional
     public StudyRoom saveRoom(Long userId, GroupStudyDTO.StudyCreateDTO requestDto) {
@@ -128,23 +128,10 @@ public class GroupStudyService {
                     .collect(Collectors.toList());
     }
 
-    public List<StudyRoom> findAllRooms() {
-        List<StudyRoom> lists = studyRoomRepository.findAll();
-        // 면접 날짜 가까운 순으로 정렬
-        Collections.sort(lists, new Comparator<StudyRoom>() {
-            @Override
-            public int compare(StudyRoom r1, StudyRoom r2) {
-                LocalDate r1Date = r1.getDate();
-                LocalDate r2Date = r2.getDate();
-                LocalTime r1Time = r1.getTime();
-                LocalTime r2Time = r2.getTime();
+    public List<StudyRoom> findRooms(Integer current) {
+        int page = current == null ? 0 : current;
+        Pageable pageRequest = PageRequest.of(page, pageSize, Sort.by("date", "time").ascending());
 
-                if(r1Date.isEqual(r2Date)) {
-                    return r2Time.isBefore(r1Time) ? 1 : -1;
-                }
-                return r2Date.isBefore(r1Date) ? 1 : -1;
-            }
-        });
-        return lists;
+        return studyRoomRepository.findAll(pageRequest).getContent();
     }
 }

--- a/src/main/java/com/witherview/groupPractice/exception/AlreadyFullStudyRoom.java
+++ b/src/main/java/com/witherview/groupPractice/exception/AlreadyFullStudyRoom.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class AlreadyFullStudyRoom extends BusinessException {
+    public AlreadyFullStudyRoom() {
+        super(ErrorCode.ALREADY_FULL_STUDYROOM);
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/exception/EmptyStudyRoom.java
+++ b/src/main/java/com/witherview/groupPractice/exception/EmptyStudyRoom.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class EmptyStudyRoom extends BusinessException {
+    public EmptyStudyRoom() {
+        super(ErrorCode.EMPTY_STUDYROOM);
+    }
+}

--- a/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
@@ -48,6 +48,8 @@ public class GroupStudyApiTest extends GroupStudySupporter {
         resultActions.andExpect(jsonPath("$.job").value(job1));
         resultActions.andExpect(jsonPath("$.date").value(date2.toString()));
         resultActions.andExpect(jsonPath("$.time").value(time2.toString()));
+        resultActions.andExpect(jsonPath("$.nowUserCnt").value(1));
+        resultActions.andExpect(jsonPath("$.maxUserCnt").value(2));
     }
 
     @Test

--- a/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
@@ -118,6 +118,20 @@ public class GroupStudyApiTest extends GroupStudySupporter {
     }
 
     @Test
+    public void 특정스터디룸_조회성공() throws Exception {
+        ResultActions resultActions = mockMvc.perform(get("/api/group/" + roomId)
+                .session(mockHttpSession))
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(jsonPath("$.title").value(title1));
+        resultActions.andExpect(jsonPath("$.description").value(description1));
+        resultActions.andExpect(jsonPath("$.industry").value(industry1));
+        resultActions.andExpect(jsonPath("$.job").value(job1));
+        resultActions.andExpect(jsonPath("$.date").value(date1.toString()));
+        resultActions.andExpect(jsonPath("$.time").value(time1.toString()));
+    }
+
+    @Test
     public void 스터디룸_등록실패_유효하지_않은_사용자() throws Exception {
         GroupStudyDTO.StudyCreateDTO dto = GroupStudyDTO.StudyCreateDTO.builder()
                 .title(title2)


### PR DESCRIPTION
## 변경 사항
- 면접스터디 스토리보드에 따라 방 생성 시 관심 산업/직무 필수로 입력하지 않아도 되게 변경
- 스터디방 조회 시 페이징 처리되어 6개씩 방이 조회되도록 변경 (면접 날짜 가까운 순으로 보여짐)   
  - 페이지 값 입력하지 않았을 때 디폴트는 0 
  - 프론트에서 스크롤 처리할 때 페이지 값 보내면 해당하는 방 조회하여 응답

## 추가 사항
- 특정 스터디방 조회하는 api 추가 
- 특정 스터디방 참여자 수 변경하고 나타낼 수 있도록 추가  
  - 입장 시 참여자수 + 1 / 퇴장 시 참여자 수 - 1 되도록 처리 
