### PR TITLE
연습 내역 조회 및 기본 질문 리스트/질문

### DIFF
--- a/src/main/java/com/witherview/account/AccountController.java
+++ b/src/main/java/com/witherview/account/AccountController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -56,4 +57,11 @@ public class AccountController {
         return new ResponseEntity<>(modelMapper.map(user, AccountDTO.ResponseLogin.class), HttpStatus.OK);
     }
 
+    @ApiOperation(value="내 정보")
+    @GetMapping(path = "/myinfo")
+    public ResponseEntity<?> myInfo(@ApiIgnore HttpSession session) {
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        AccountDTO.ResponseMyInfo info = accountService.myInfo(accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(info, AccountDTO.ResponseMyInfo.class), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/witherview/account/AccountController.java
+++ b/src/main/java/com/witherview/account/AccountController.java
@@ -58,7 +58,7 @@ public class AccountController {
     }
 
     @ApiOperation(value="내 정보")
-    @GetMapping(path = "/myinfo")
+    @GetMapping(path = "/api/myinfo")
     public ResponseEntity<?> myInfo(@ApiIgnore HttpSession session) {
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
         AccountDTO.ResponseMyInfo info = accountService.myInfo(accountSession.getId());

--- a/src/main/java/com/witherview/account/AccountDTO.java
+++ b/src/main/java/com/witherview/account/AccountDTO.java
@@ -60,7 +60,7 @@ public class AccountDTO {
         private Long groupStudyCnt;
         private Long selfPracticeCnt;
         private Long questionListCnt;
-        private Double interviewScore;
+        private String interviewScore;
         private Long passCnt;
         private Long failCnt;
     }

--- a/src/main/java/com/witherview/account/AccountDTO.java
+++ b/src/main/java/com/witherview/account/AccountDTO.java
@@ -54,4 +54,14 @@ public class AccountDTO {
         private String email;
         private String name;
     }
+
+    @Getter @Setter
+    public static class ResponseMyInfo {
+        private Long groupStudyCnt;
+        private Long selfPracticeCnt;
+        private Long questionListCnt;
+        private Double interviewScore;
+        private Long passCnt;
+        private Long failCnt;
+    }
 }

--- a/src/main/java/com/witherview/account/AccountService.java
+++ b/src/main/java/com/witherview/account/AccountService.java
@@ -71,7 +71,7 @@ public class AccountService {
                 .mapToDouble(StudyFeedback::getScore)
                 .average()
                 .orElse(0);
-        long passCnt = feedbackList
+        Long passCnt = feedbackList
                 .stream()
                 .filter(StudyFeedback::getPassOrFail)
                 .count();

--- a/src/main/java/com/witherview/account/AccountService.java
+++ b/src/main/java/com/witherview/account/AccountService.java
@@ -3,9 +3,7 @@ package com.witherview.account;
 import com.witherview.account.exception.DuplicateEmail;
 import com.witherview.account.exception.InvalidLogin;
 import com.witherview.account.exception.NotEqualPassword;
-import com.witherview.database.entity.StudyFeedback;
-import com.witherview.database.entity.StudyRoom;
-import com.witherview.database.entity.User;
+import com.witherview.database.entity.*;
 import com.witherview.database.repository.UserRepository;
 import com.witherview.selfPractice.exception.NotFoundUser;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,7 +30,27 @@ public class AccountService {
         if (findUser != null) {
             throw new DuplicateEmail();
         }
-        return userRepository.save(new User(dto.getEmail(), passwordEncoder.encode(dto.getPassword()), dto.getName()));
+        User user = new User(dto.getEmail(), passwordEncoder.encode(dto.getPassword()), dto.getName());
+        String title = "기본 질문 리스트";
+        String enterprise = "공통";
+        String job = "공통";
+        QuestionList questionList = new QuestionList(title, enterprise, job);
+        questionList.addQuestion(new Question("간단한 자기소개 해주세요.", "", 1));
+        questionList.addQuestion(new Question("왜 지원 직무가 하고 싶은 가요?", "", 2));
+        questionList.addQuestion(new Question("지원 직무 핵심 역량은 무엇이라고 생각하나요?", "", 3));
+        questionList.addQuestion(new Question("그 역량을 갖추기 위해 어떤 노력을 했는지 구체적으로 말씀해 주시겠어요?", "", 4));
+        questionList.addQuestion(new Question("비슷한 경험을 한 지원자들보다 내가 더 탁월하다고 이야기할 수 있는 근거가 있을까요?", "", 5));
+        questionList.addQuestion(new Question("직원 직무 관련 준비가 되었다고 주장할 게 있다면 1가지만 더 이야기 해보시겠어요?", "", 6));
+        questionList.addQuestion(new Question("성격의 장점과 단점은 무엇인가요?", "", 7));
+        questionList.addQuestion(new Question("팀 프로젝트에서 갈등 상황을 어떻게 해결하시는 편인가요?", "", 8));
+        questionList.addQuestion(new Question("우리 회사 지원동기에 대해서 설명해주세요.", "", 9));
+        questionList.addQuestion(new Question("우리 회사에 대해서 그냥 아는 대로 설명해보실래요?", "", 10));
+        questionList.addQuestion(new Question("우리 회사 경쟁사는 어디라고 생각하나요? 그 경쟁사보다 우리가 더 나은 점은 무엇인가요?", "", 11));
+        questionList.addQuestion(new Question("우리 회사가 속한 산업의 전망이 어떻게 될 것 같나요?", "", 12));
+        questionList.addQuestion(new Question("입사 후 우리 회사에서 이루고자 하는 목표가 있나요?", "", 13));
+        questionList.addQuestion(new Question("마지막으로 하고 싶은 이야기나 질문 있으신가요?", "", 14));
+        user.addQuestionList(questionList);
+        return userRepository.save(user);
     }
 
     public User login(AccountDTO.LoginDTO dto) {

--- a/src/main/java/com/witherview/account/AccountService.java
+++ b/src/main/java/com/witherview/account/AccountService.java
@@ -71,7 +71,7 @@ public class AccountService {
         responseMyInfo.setGroupStudyCnt(studyCnt);
         responseMyInfo.setPassCnt(passCnt);
         responseMyInfo.setFailCnt(failCnt);
-        responseMyInfo.setInterviewScore(interviewScore);
+        responseMyInfo.setInterviewScore(String.format("%.1f", interviewScore));
         responseMyInfo.setQuestionListCnt(questionListCnt);
         return responseMyInfo;
     }

--- a/src/main/java/com/witherview/account/AccountService.java
+++ b/src/main/java/com/witherview/account/AccountService.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,20 +36,19 @@ public class AccountService {
         String enterprise = "공통";
         String job = "공통";
         QuestionList questionList = new QuestionList(title, enterprise, job);
-        questionList.addQuestion(new Question("간단한 자기소개 해주세요.", "", 1));
-        questionList.addQuestion(new Question("왜 지원 직무가 하고 싶은 가요?", "", 2));
-        questionList.addQuestion(new Question("지원 직무 핵심 역량은 무엇이라고 생각하나요?", "", 3));
-        questionList.addQuestion(new Question("그 역량을 갖추기 위해 어떤 노력을 했는지 구체적으로 말씀해 주시겠어요?", "", 4));
-        questionList.addQuestion(new Question("비슷한 경험을 한 지원자들보다 내가 더 탁월하다고 이야기할 수 있는 근거가 있을까요?", "", 5));
-        questionList.addQuestion(new Question("직원 직무 관련 준비가 되었다고 주장할 게 있다면 1가지만 더 이야기 해보시겠어요?", "", 6));
-        questionList.addQuestion(new Question("성격의 장점과 단점은 무엇인가요?", "", 7));
-        questionList.addQuestion(new Question("팀 프로젝트에서 갈등 상황을 어떻게 해결하시는 편인가요?", "", 8));
-        questionList.addQuestion(new Question("우리 회사 지원동기에 대해서 설명해주세요.", "", 9));
-        questionList.addQuestion(new Question("우리 회사에 대해서 그냥 아는 대로 설명해보실래요?", "", 10));
-        questionList.addQuestion(new Question("우리 회사 경쟁사는 어디라고 생각하나요? 그 경쟁사보다 우리가 더 나은 점은 무엇인가요?", "", 11));
-        questionList.addQuestion(new Question("우리 회사가 속한 산업의 전망이 어떻게 될 것 같나요?", "", 12));
-        questionList.addQuestion(new Question("입사 후 우리 회사에서 이루고자 하는 목표가 있나요?", "", 13));
-        questionList.addQuestion(new Question("마지막으로 하고 싶은 이야기나 질문 있으신가요?", "", 14));
+        List<String> list = new ArrayList<>();
+        list.add("간단한 자기소개 해주세요."); list.add("왜 지원 직무가 하고 싶은 가요?");
+        list.add("지원 직무 핵심 역량은 무엇이라고 생각하나요?");  list.add("그 역량을 갖추기 위해 어떤 노력을 했는지 구체적으로 말씀해 주시겠어요?");
+        list.add("비슷한 경험을 한 지원자들보다 내가 더 탁월하다고 이야기할 수 있는 근거가 있을까요?");
+        list.add("직원 직무 관련 준비가 되었다고 주장할 게 있다면 1가지만 더 이야기 해보시겠어요?");
+        list.add("성격의 장점과 단점은 무엇인가요?"); list.add("팀 프로젝트에서 갈등 상황을 어떻게 해결하시는 편인가요?");
+        list.add("우리 회사 지원동기에 대해서 설명해주세요.");    list.add("우리 회사에 대해서 그냥 아는 대로 설명해보실래요?");
+        list.add("우리 회사 경쟁사는 어디라고 생각하나요? 그 경쟁사보다 우리가 더 나은 점은 무엇인가요?");
+        list.add("우리 회사가 속한 산업의 전망이 어떻게 될 것 같나요?"); list.add("입사 후 우리 회사에서 이루고자 하는 목표가 있나요?");
+        list.add("마지막으로 하고 싶은 이야기나 질문 있으신가요?");
+        for (int i = 1; i <= list.size(); i++) {
+            questionList.addQuestion(new Question(list.get(i), "", i));
+        }
         user.addQuestionList(questionList);
         return userRepository.save(user);
     }

--- a/src/main/java/com/witherview/database/entity/User.java
+++ b/src/main/java/com/witherview/database/entity/User.java
@@ -69,6 +69,10 @@ public class User {
         this.name = name;
     }
 
+    public void increaseSelfPracticeCnt() {
+        this.selfPracticeCnt += 1;
+    }
+
     public void addQuestionList(QuestionList questionList) {
         questionList.updateOwner(this);
         this.questionLists.add(questionList);

--- a/src/main/java/com/witherview/database/entity/User.java
+++ b/src/main/java/com/witherview/database/entity/User.java
@@ -39,9 +39,6 @@ public class User {
     private String subJob;
 
     @ColumnDefault("0")
-    private Long studyCnt;
-
-    @ColumnDefault("0")
     private Long selfPracticeCnt;
 
     @ColumnDefault("0")

--- a/src/main/java/com/witherview/database/entity/User.java
+++ b/src/main/java/com/witherview/database/entity/User.java
@@ -39,10 +39,10 @@ public class User {
     private String subJob;
 
     @ColumnDefault("0")
-    private Integer studyCnt;
+    private Long studyCnt;
 
     @ColumnDefault("0")
-    private Integer selfPracticeCnt;
+    private Long selfPracticeCnt;
 
     @ColumnDefault("0")
     private Byte reliability;

--- a/src/main/java/com/witherview/selfPractice/history/SelfHistoryService.java
+++ b/src/main/java/com/witherview/selfPractice/history/SelfHistoryService.java
@@ -44,6 +44,7 @@ public class SelfHistoryService {
         String savedLocation = videoService.upload(videoFile,
                                            accountSession.getEmail() + "/self/" + selfHistory.getId());
         selfHistory.updateSavedLocation(savedLocation);
+        user.increaseSelfPracticeCnt();
         return selfHistory;
     }
 

--- a/src/test/java/com/witherview/account/RegisterServiceTest.java
+++ b/src/test/java/com/witherview/account/RegisterServiceTest.java
@@ -1,0 +1,31 @@
+package com.witherview.account;
+
+import com.witherview.database.entity.User;
+import com.witherview.selfPractice.exception.NotFoundUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+public class RegisterServiceTest extends AccountSupporter {
+    @Autowired
+    AccountService accountService;
+
+    @Test
+    public void 회원가입_성공케이스_질문리스트_및_질문_갯수_확인() throws Exception {
+        AccountDTO.RegisterDTO dto = new AccountDTO.RegisterDTO();
+        dto.setEmail(email);
+        dto.setName(name);
+        dto.setPassword(password);
+        dto.setPasswordConfirm(password);
+
+        Long registerdUserId = accountService.register(dto).getId();
+        User user = userRepository.findById(registerdUserId).orElseThrow(NotFoundUser::new);
+
+        assertEquals(1, user.getQuestionLists().size());
+        assertEquals(14, user.getQuestionLists().get(0).getQuestions().size());
+    }
+}


### PR DESCRIPTION
## 추가한 사항
- 마이페이지에서 연습 내역 조회하기 위한 API
- 회원가입시 추가적으로 기본 질문 리스트/질문 추가
- 혼자 연습 완료시(History 등록할 때) 혼자 연습 횟수 증가

## 수정한 사항
- 유저 `Entity`에서 그룹 스터디 횟수 cnt 컬럼 삭제