### PR TITLE
Hotfix. 특정 방 참여자 조회할 때 필수 응답 값 빠진 부분 수정 

### DIFF
--- a/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
@@ -96,6 +96,7 @@ public class GroupStudyDTO {
 
     @Getter @Setter
     public static class ParticipantDTO {
+        private Long id;
         private String email;
         private String name;
     }


### PR DESCRIPTION
## 수정한 부분
그룹스터디에서 특정 방 참여자 조회할 때 유저의 id 값이 응답메세지에 빠져있어서 dto에 id 값 추가했습니다!