### PR TITLE
그룹 스터디 관련 예외 처리 로직 추가 

### DIFF
--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode {
     NOT_JOIN_STUDYROOM(400, "GROUP-PRACTICE003", "참여하지 않은 스터디룸입니다."),
     ALREADY_FULL_STUDYROOM(400, "GROUP-PRACTICE004", "이미 스터디룸이 꽉 차 있습니다."),
     EMPTY_STUDYROOM(400, "GROUP-PRACTICE005", "스터디룸에 참여자가 없으면 안됩니다."),
-    NOT_CREATED_FEEDBACK(400, "GROUP-PRACTICE006", "스터디룸에 참여하지 않은 사람에게 피드백을 줄 수 없습니다."),
+    NOT_CREATED_FEEDBACK(404, "GROUP-PRACTICE006", "스터디룸에 참여하지 않은 사람에게 피드백을 줄 수 없습니다."),
     NOT_STUDYROOM_HOST(400, "GROUP-PRACTICE007", "해당 스터디룸의 호스트가 아닙니다."),
 
     // Self-History

--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     NOT_JOIN_STUDYROOM(400, "GROUP-PRACTICE003", "참여하지 않은 스터디룸입니다."),
     ALREADY_FULL_STUDYROOM(400, "GROUP-PRACTICE004", "이미 스터디룸이 꽉 차 있습니다."),
     EMPTY_STUDYROOM(400, "GROUP-PRACTICE005", "스터디룸에 참여자가 없으면 안됩니다."),
+    NOT_CREATED_FEEDBACK(400, "GROUP-PRACTICE006", "스터디룸에 참여하지 않은 사람에게 피드백을 줄 수 없습니다."),
+    NOT_STUDYROOM_HOST(400, "GROUP-PRACTICE007", "해당 스터디룸의 호스트가 아닙니다."),
 
     // Self-History
     NOT_FOUND_HISTORY(404, "SELF-HISTORY001", "해당 혼자 연습 내역이 없습니다."),

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -50,14 +50,16 @@ public class GroupStudyController {
     @ApiOperation(value="스터디방 수정")
     @PatchMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> updateQuestion(@RequestBody @Valid GroupStudyDTO.StudyUpdateDTO requestDto,
-                                            BindingResult result) {
+                                            BindingResult result,
+                                            @ApiIgnore HttpSession session) {
 
         if(result.hasErrors()) {
             ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
             return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
         }
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        groupStudyService.updateRoom(accountSession.getId(), requestDto);
 
-        groupStudyService.updateRoom(requestDto);
         StudyRoom studyRoom = groupStudyService.findRoom(requestDto.getId());
         return new ResponseEntity<>(modelMapper.map(studyRoom, GroupStudyDTO.ResponseDTO.class), HttpStatus.OK);
     }
@@ -87,8 +89,10 @@ public class GroupStudyController {
 
     @ApiOperation(value="스터디방 삭제")
     @DeleteMapping(path = "/{id}")
-    public ResponseEntity<?> deleteRoom(@ApiParam(value = "삭제할 방 id", required = true) @PathVariable Long id) {
-        StudyRoom deletedRoom = groupStudyService.deleteRoom(id);
+    public ResponseEntity<?> deleteRoom(@ApiParam(value = "삭제할 방 id", required = true) @PathVariable Long id,
+                                        @ApiIgnore HttpSession session) {
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        StudyRoom deletedRoom = groupStudyService.deleteRoom(id, accountSession.getId());
         return new ResponseEntity<>(modelMapper.map(deletedRoom, GroupStudyDTO.DeleteResponseDTO.class), HttpStatus.OK);
     }
 

--- a/src/main/java/com/witherview/groupPractice/exception/NotCreatedFeedback.java
+++ b/src/main/java/com/witherview/groupPractice/exception/NotCreatedFeedback.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class NotCreatedFeedback extends BusinessException {
+    public NotCreatedFeedback() {
+        super(ErrorCode.NOT_CREATED_FEEDBACK);
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/exception/NotStudyRoomHost.java
+++ b/src/main/java/com/witherview/groupPractice/exception/NotStudyRoomHost.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class NotStudyRoomHost extends BusinessException {
+    public NotStudyRoomHost() {
+        super(ErrorCode.NOT_STUDYROOM_HOST);
+    }
+}

--- a/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
@@ -224,10 +224,10 @@ public class GroupStudyApiTest extends GroupStudySupporter {
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print())
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isNotFound());
 
         resultActions.andExpect(jsonPath("$.message").value("스터디룸에 참여하지 않은 사람에게 피드백을 줄 수 없습니다."));
-        resultActions.andExpect(jsonPath("$.status").value(400));
+        resultActions.andExpect(jsonPath("$.status").value(404));
     }
 
     @Test

--- a/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
@@ -2,6 +2,7 @@ package com.witherview.groupPractice;
 
 import com.witherview.account.AccountSession;
 import com.witherview.database.entity.StudyRoom;
+import com.witherview.database.entity.StudyRoomParticipant;
 import com.witherview.database.entity.User;
 import com.witherview.database.repository.StudyRoomRepository;
 import com.witherview.database.repository.UserRepository;
@@ -67,5 +68,13 @@ public class GroupStudySupporter extends MockMvcSupporter {
         StudyRoom studyRoom = new StudyRoom(title1, description1, industry1, job1, date1, time1);
         user1.addHostedRoom(studyRoom);
         roomId = studyRoomRepository.save(studyRoom).getId();
+
+        StudyRoomParticipant studyRoomParticipant = StudyRoomParticipant.builder()
+                .studyRoom(studyRoom)
+                .user(user1)
+                .build();
+
+        studyRoom.addParticipants(studyRoomParticipant);
+        user1.addParticipatedRoom(studyRoomParticipant);
     }
 }


### PR DESCRIPTION
### 추가한 사항
- 스터디룸 호스트가 아닌 유저가 스터디룸 수정/삭제 시도할 때 에러 처리
- 참여하지 않은 스터디룸의 피드백을 남기려고 하거나 피드백 대상이 해당 스터디룸 참여자가 아닌 경우 에러 처리

정상적인 접근이거나 일반적인 상황이라면 사실 이럴 경우가 거의 없겠지만,, 
혹시 모를 상황에 대비하여 예외 로직 몇가지 추가하였습니다..ㅎㅎ
