### PR TITLE
스터디룸 삭제 안되던 오류 해결 및 특정 스터디룸 참가자 조회 시 응답값 추가 

### DIFF
--- a/src/main/java/com/witherview/account/AccountService.java
+++ b/src/main/java/com/witherview/account/AccountService.java
@@ -79,7 +79,6 @@ public class AccountService {
         Long studyCnt = (long) feedbackList
                 .stream()
                 .map(StudyFeedback::getStudyRoom)
-                .map(StudyRoom::getId)
                 .collect(Collectors.toSet())
                 .size();
         Long questionListCnt = (long) user.getQuestionLists().size();

--- a/src/main/java/com/witherview/database/entity/StudyFeedback.java
+++ b/src/main/java/com/witherview/database/entity/StudyFeedback.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Entity @Getter
@@ -24,9 +23,8 @@ public class StudyFeedback extends CreatedBaseEntity {
     @JoinColumn(name = "written_user_id", nullable = false)
     private User writtenUser;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_room_id", nullable = false)
-    private StudyRoom studyRoom;
+    @NotNull
+    private Long studyRoom;
 
     @NotNull
     private Byte score;
@@ -35,7 +33,7 @@ public class StudyFeedback extends CreatedBaseEntity {
     private Boolean passOrFail;
 
     @Builder
-    public StudyFeedback(StudyRoom studyRoom, User writtenUser,
+    public StudyFeedback(Long studyRoom, User writtenUser,
                          Byte score, Boolean passOrFail) {
         this.studyRoom = studyRoom;
         this.writtenUser = writtenUser;

--- a/src/main/java/com/witherview/database/entity/User.java
+++ b/src/main/java/com/witherview/database/entity/User.java
@@ -42,7 +42,7 @@ public class User {
     private Long selfPracticeCnt = 0L;
 
     @ColumnDefault("0")
-    private Byte reliability = 0;
+    private Byte reliability = 70;
 
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<QuestionList> questionLists = new ArrayList<>();

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -114,7 +114,7 @@ public class GroupStudyController {
     @ApiOperation(value="해당 스터디방 참여자 조회")
     @GetMapping(path = "/room/{id}")
     public ResponseEntity<?> findParticipants(@ApiParam(value = "참여 조회할 방 id", required = true) @PathVariable Long id) {
-        List<User> lists = groupStudyService.findParticipatedUsers(id);
+        List<GroupStudyDTO.ParticipantDTO> lists = groupStudyService.findParticipatedUsers(id);
         return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ParticipantDTO[].class), HttpStatus.OK);
     }
 

--- a/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
@@ -99,6 +99,9 @@ public class GroupStudyDTO {
         private Long id;
         private String email;
         private String name;
+        private Long groupStudyCnt;
+        private Byte reliability;
+        private Boolean isHost;
     }
 
     @Getter @Setter

--- a/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
@@ -143,6 +143,36 @@ public class GroupStudyApiTest extends GroupStudySupporter {
     }
 
     @Test
+    public void 특정스터디룸_참여자_조회성공() throws Exception {
+        ResultActions resultActions = mockMvc.perform(get("/api/group/room/" + roomId)
+                .session(mockHttpSession))
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(jsonPath("$[0].id").value(userId1));
+        resultActions.andExpect(jsonPath("$[0].email").value(email1));
+        resultActions.andExpect(jsonPath("$[0].name").value(name1));
+        resultActions.andExpect(jsonPath("$[0].groupStudyCnt").value(1));
+        resultActions.andExpect(jsonPath("$[0].reliability").value(70));
+        resultActions.andExpect(jsonPath("$[0].isHost").value(true));
+
+        resultActions.andExpect(jsonPath("$[1].id").value(userId3));
+        resultActions.andExpect(jsonPath("$[1].email").value(email3));
+        resultActions.andExpect(jsonPath("$[1].name").value(name3));
+        resultActions.andExpect(jsonPath("$[1].groupStudyCnt").value(1));
+        resultActions.andExpect(jsonPath("$[1].reliability").value(70));
+        resultActions.andExpect(jsonPath("$[1].isHost").value(false));
+    }
+
+    @Test
+    public void 스터디룸_삭제_성공() throws Exception {
+        ResultActions resultActions = mockMvc.perform(delete("/api/group/" + roomId)
+                .session(mockHttpSession))
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(jsonPath("$.id").value(roomId));
+    }
+
+    @Test
     public void 스터디룸_등록실패_유효하지_않은_사용자() throws Exception {
         GroupStudyDTO.StudyCreateDTO dto = GroupStudyDTO.StudyCreateDTO.builder()
                 .title(title2)

--- a/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
@@ -1,9 +1,11 @@
 package com.witherview.groupPractice;
 
 import com.witherview.account.AccountSession;
+import com.witherview.database.entity.StudyFeedback;
 import com.witherview.database.entity.StudyRoom;
 import com.witherview.database.entity.StudyRoomParticipant;
 import com.witherview.database.entity.User;
+import com.witherview.database.repository.StudyFeedbackRepository;
 import com.witherview.database.repository.StudyRoomRepository;
 import com.witherview.database.repository.UserRepository;
 import com.witherview.support.MockMvcSupporter;
@@ -24,6 +26,9 @@ public class GroupStudySupporter extends MockMvcSupporter {
     final String email2 = "yayaya@witherview.com";
     final String password2 = "123456";
     final String name2 = "yapp";
+    final String email3 = "yoyoyo@witherview.com";
+    final String password3 = "123456";
+    final String name3 = "web2";
     final String title1 = "네이버 빅데이터 플랫폼 스터디 모집합니다.";
     final String description1 =  "코딩테스트 합격자만 신청바랍니다!!!!";
     final String industry1 = "it서비스";
@@ -41,12 +46,16 @@ public class GroupStudySupporter extends MockMvcSupporter {
     final MockHttpSession mockHttpSession = new MockHttpSession();
     Long userId1 = (long)1;
     Long userId2 = (long)2;
-    Long roomId = (long) 3;
+    Long userId3 = (long)3;
+    Long roomId = (long) 4;
     @Autowired
     UserRepository userRepository;
 
     @Autowired
     StudyRoomRepository studyRoomRepository;
+
+    @Autowired
+    StudyFeedbackRepository studyFeedbackRepository;
 
     @Autowired
     PasswordEncoder passwordEncoder;
@@ -60,6 +69,9 @@ public class GroupStudySupporter extends MockMvcSupporter {
         User user2 = userRepository.save(new User(email2, passwordEncoder.encode(password2), name2));
         userId2 = user2.getId();
 
+        User user3 = userRepository.save(new User(email3, passwordEncoder.encode(password3), name3));
+        userId3 = user3.getId();
+
         // 세션생성
         AccountSession accountSession = new AccountSession(userId1, email1, name1);
         mockHttpSession.setAttribute("user", accountSession);
@@ -69,12 +81,41 @@ public class GroupStudySupporter extends MockMvcSupporter {
         user1.addHostedRoom(studyRoom);
         roomId = studyRoomRepository.save(studyRoom).getId();
 
-        StudyRoomParticipant studyRoomParticipant = StudyRoomParticipant.builder()
+        StudyRoomParticipant studyRoomParticipant1 = StudyRoomParticipant.builder()
                 .studyRoom(studyRoom)
                 .user(user1)
                 .build();
 
-        studyRoom.addParticipants(studyRoomParticipant);
-        user1.addParticipatedRoom(studyRoomParticipant);
+        studyRoom.addParticipants(studyRoomParticipant1);
+        user1.addParticipatedRoom(studyRoomParticipant1);
+
+        StudyRoomParticipant studyRoomParticipant2 = StudyRoomParticipant.builder()
+                .studyRoom(studyRoom)
+                .user(user3)
+                .build();
+
+        studyRoom.addParticipants(studyRoomParticipant2);
+        user3.addParticipatedRoom(studyRoomParticipant2);
+
+        // 피드백 등록
+        StudyFeedback studyFeedback1 = StudyFeedback.builder()
+                .studyRoom(roomId)
+                .writtenUser(user1)
+                .score(score)
+                .passOrFail(passOrFail)
+                .build();
+
+        user3.addStudyFeedback(studyFeedback1);
+        studyFeedbackRepository.save(studyFeedback1);
+
+        StudyFeedback studyFeedback2 = StudyFeedback.builder()
+                .studyRoom(roomId)
+                .writtenUser(user3)
+                .score(score)
+                .passOrFail(passOrFail)
+                .build();
+
+        user1.addStudyFeedback(studyFeedback2);
+        studyFeedbackRepository.save(studyFeedback2);
     }
 }


### PR DESCRIPTION
## 변경 사항
- 초기 유저 신뢰도 70으로 변경
- 스터디룸과 스터디피드백 간의 연관관계 해제하여 스터디피드백 존재하는 경우 연관관계때문에 스터디룸 삭제 안되던 오류 해결 ( 더 나은 방법이 있을지는 좀 더 고민해봐야함..)

## 추가 사항
- 특정 스터디룸 참가자 조회 시 응답값에 `신뢰도, 스터디 참여횟수, 호스트 여부` 추가 