### PR TITLE
그룹스터디 전반적인 구조 수정 / 스터디 중 피드백 채팅 저장 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	// websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/witherview/account/AccountService.java
+++ b/src/main/java/com/witherview/account/AccountService.java
@@ -65,7 +65,10 @@ public class AccountService {
     public AccountDTO.ResponseMyInfo myInfo(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
         AccountDTO.ResponseMyInfo responseMyInfo = new AccountDTO.ResponseMyInfo();
-        List<StudyFeedback> feedbackList = user.getStudyFeedbacks();
+        List<StudyFeedback> feedbackList = new ArrayList<>();
+        user.getStudyHistories()
+                .stream()
+                .forEach(v -> v.getStudyFeedbacks().forEach(e -> feedbackList.add(e)));
 
         Double interviewScore = feedbackList
                 .stream()
@@ -77,15 +80,10 @@ public class AccountService {
                 .filter(StudyFeedback::getPassOrFail)
                 .count();
         Long failCnt = feedbackList.size() - passCnt;
-        Long studyCnt = (long) feedbackList
-                .stream()
-                .map(StudyFeedback::getStudyRoom)
-                .collect(Collectors.toSet())
-                .size();
         Long questionListCnt = (long) user.getQuestionLists().size();
 
         responseMyInfo.setSelfPracticeCnt(user.getSelfPracticeCnt());
-        responseMyInfo.setGroupStudyCnt(studyCnt);
+        responseMyInfo.setGroupStudyCnt(user.getGroupPracticeCnt());
         responseMyInfo.setPassCnt(passCnt);
         responseMyInfo.setFailCnt(failCnt);
         responseMyInfo.setInterviewScore(String.format("%.1f", interviewScore));

--- a/src/main/java/com/witherview/chat/ChatController.java
+++ b/src/main/java/com/witherview/chat/ChatController.java
@@ -1,14 +1,41 @@
 package com.witherview.chat;
 
+import com.google.gson.Gson;
+import com.witherview.account.AccountSession;
+import com.witherview.database.entity.FeedBackChat;
+import com.witherview.exception.ErrorResponse;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+import java.util.List;
+
+import static com.witherview.exception.ErrorCode.INVALID_INPUT_VALUE;
 
 @RequiredArgsConstructor
 @Controller
 public class ChatController {
+    private final ChatService chatService;
+    private final RedisTemplate redisTemplate;
+    private final ChannelTopic channelTopic;
+    private final Gson gson;
     private final SimpMessageSendingOperations messagingTemplate;
+    private final ModelMapper modelMapper;
 
     @MessageMapping("/chat")
     public void message(ChatDTO.MessageDTO message) {
@@ -16,7 +43,37 @@ public class ChatController {
     }
 
     @MessageMapping("/feedback")
-    public void feedback(ChatDTO.FeedBackDTO feedback) {
-        messagingTemplate.convertAndSend("/sub/feedback/" + feedback.getRoomId(), feedback);
+    public void feedback(@Valid ChatDTO.FeedBackDTO feedback) {
+        redisTemplate.convertAndSend(channelTopic.getTopic(),
+                gson.toJson(chatService.saveRedis(feedback.getStudyHistoryId(), feedback)));
+    }
+
+    @MessageExceptionHandler
+    public String handleException(Throwable exception) {
+        return exception.getMessage();
+    }
+
+    @ApiOperation(value="그룹스터디 피드백 내용 등록")
+    @PostMapping(path = "/api/message/feedback", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> saveFeedBackMessage(@RequestBody @Valid ChatDTO.SaveDTO requestDto,
+                                  BindingResult result) {
+        if(result.hasErrors()) {
+            ErrorResponse errorResponse = ErrorResponse.of(INVALID_INPUT_VALUE, result);
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        }
+        List<FeedBackChat> lists = chatService.saveFeedbackMessage(requestDto);
+        return new ResponseEntity<>(modelMapper.map(lists, ChatDTO.SavedFeedBackDTO[].class), HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value="그룹스터디 피드백 내용 조회")
+    @GetMapping(path = "/api/message/feedback")
+    public ResponseEntity<?> getFeedBackMessage(@ApiParam(value = "조회할 스터디 내역 id") @RequestParam(value = "historyId") Long historyId,
+                                                @ApiParam(value = "조회할 피드백 메세지 idx (디폴트 값 = 0)")
+                                                @RequestParam(value = "idx", required = false) Integer current,
+                                                @ApiIgnore HttpSession session) {
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        List<FeedBackChat> lists = chatService.getFeedbackMessage(historyId, accountSession.getId(), current);
+        return new ResponseEntity<>(modelMapper.map(lists, ChatDTO.SavedFeedBackDTO[].class), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/witherview/chat/ChatDTO.java
+++ b/src/main/java/com/witherview/chat/ChatDTO.java
@@ -3,6 +3,9 @@ package com.witherview.chat;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public class ChatDTO {
@@ -18,9 +21,35 @@ public class ChatDTO {
     @Getter @Setter
     public static class FeedBackDTO {
         private String id = UUID.randomUUID().toString(); // message id
-        private Long roomId; // 방 번호
-        private String sender; // 피드백 보낸사람
-        private String target; // 피드백 받는사람
-        private String feedbacks; // 피드백
+
+        @NotNull(message = "스터디 연습내역 아이디는 반드시 입력해야 합니다.")
+        private Long studyHistoryId; // 방 번호
+
+        @NotNull(message = "피드백 보낸사람 아이디는 반드시 입력해야 합니다.")
+        private Long writtenUserId; // 피드백 보낸사람
+
+        @NotNull(message = "피드백 받는사람 아이디는 반드시 입력해야 합니다.")
+        private Long targetUserId; // 피드백 받는사람
+
+        @NotBlank(message = "피드백 메세지는 반드시 입력해야 합니다.")
+        private String message; // 피드백
+
+        private String createdAt;
+    }
+
+    @Getter @Setter
+    public static class SaveDTO {
+        @NotNull(message = "스터디 연습내역 아이디는 반드시 입력해야 합니다.")
+        private Long studyHistoryId;
+    }
+
+    @Getter @Setter
+    public static class SavedFeedBackDTO {
+        private Long id;
+        private Long studyHistoryId; // 스터디 연습내역 아이디
+        private Long writtenUserId; // 피드백 보낸사람
+        private Long targetUserId; // 피드백 받는사람
+        private String message; // 피드백
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/witherview/chat/ChatService.java
+++ b/src/main/java/com/witherview/chat/ChatService.java
@@ -1,4 +1,104 @@
 package com.witherview.chat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.witherview.chat.exception.NotSavedFeedBackChat;
+import com.witherview.database.entity.FeedBackChat;
+import com.witherview.database.entity.StudyHistory;
+import com.witherview.database.entity.StudyRoom;
+import com.witherview.database.entity.User;
+import com.witherview.database.repository.FeedBackChatRepository;
+import com.witherview.database.repository.StudyHistoryRepository;
+import com.witherview.database.repository.StudyRoomRepository;
+import com.witherview.database.repository.UserRepository;
+import com.witherview.groupPractice.exception.NotFoundStudyHistory;
+import com.witherview.groupPractice.exception.NotFoundStudyRoom;
+import com.witherview.groupPractice.exception.NotOwnedStudyHistory;
+import com.witherview.selfPractice.exception.NotFoundUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
 public class ChatService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final Gson gson;
+    private final FeedBackChatRepository feedBackChatRepository;
+    private final UserRepository userRepository;
+    private final StudyHistoryRepository studyHistoryRepository;
+
+    // 캐싱 용도로 피드백메세지 레디스에 임시 저장
+    @Transactional
+    public ChatDTO.FeedBackDTO saveRedis(Long studyHistoryId, ChatDTO.FeedBackDTO message) {
+        message.setCreatedAt(LocalDateTime.now().toString());
+
+        redisTemplate.opsForList().rightPush(studyHistoryId.toString(), gson.toJson(message));
+        return message;
+    }
+
+    @Transactional
+    public List<FeedBackChat> saveFeedbackMessage(ChatDTO.SaveDTO requestDto) {
+        String historyId = requestDto.getStudyHistoryId().toString();
+
+        List<FeedBackChat> lists =  redisTemplate.opsForList().range(historyId, 0, -1)
+                .stream()
+                .map(message -> {
+                    try{
+                        ChatDTO.FeedBackDTO dto =  objectMapper.readValue(message.toString(), ChatDTO.FeedBackDTO.class);
+
+                        User writtenUser = findUser(dto.getWrittenUserId());
+                        User targetUser = findUser(dto.getTargetUserId());
+                        StudyHistory studyHistory = findStudyHistory(dto.getStudyHistoryId());
+
+                        FeedBackChat feedBackChat = FeedBackChat.builder()
+                                .studyHistory(studyHistory)
+                                .writtenUser(writtenUser)
+                                .targetUser(targetUser)
+                                .message(dto.getMessage())
+                                .createdAt(LocalDateTime.parse(dto.getCreatedAt()))
+                                .build();
+
+                        return feedBackChatRepository.save(feedBackChat);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        throw new NotSavedFeedBackChat();
+                    }
+                })
+                .collect(Collectors.toList());
+
+        redisTemplate.delete(historyId);
+        return lists;
+    }
+
+    public List<FeedBackChat> getFeedbackMessage(Long historyId, Long userId, Integer idx) {
+        StudyHistory studyHistory = findStudyHistory(historyId);
+        if(studyHistory.getUser().getId() != userId) throw new NotOwnedStudyHistory();
+
+        int page = idx == null ? 0 : idx;
+        Pageable pageRequest = PageRequest.of(page, 10, Sort.by("createdAt").ascending());
+        return feedBackChatRepository.findAllByStudyHistoryId(pageRequest, historyId);
+    }
+
+    public StudyHistory findStudyHistory(Long id) {
+        return studyHistoryRepository.findById(id).orElseThrow(NotFoundStudyHistory::new);
+    }
+
+    public User findUser(Long id) {
+        return userRepository.findById(id).orElseThrow(NotFoundUser::new);
+    }
+
+    public User findUserByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
 }

--- a/src/main/java/com/witherview/chat/RedisSubscriber.java
+++ b/src/main/java/com/witherview/chat/RedisSubscriber.java
@@ -1,0 +1,24 @@
+package com.witherview.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@AllArgsConstructor
+@Service
+public class RedisSubscriber {
+    private final ObjectMapper objectMapper;
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    public void sendMessage(String message) {
+        try {
+            ChatDTO.FeedBackDTO feedBackDTO = objectMapper.readValue(message, ChatDTO.FeedBackDTO.class);
+            messagingTemplate.convertAndSend("/sub/feedback/" + feedBackDTO.getStudyHistoryId(), message);
+        } catch (Exception e) {
+            log.error("Exception {}", e);
+        }
+    }
+}

--- a/src/main/java/com/witherview/chat/exception/NotSavedFeedBackChat.java
+++ b/src/main/java/com/witherview/chat/exception/NotSavedFeedBackChat.java
@@ -1,0 +1,10 @@
+package com.witherview.chat.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class NotSavedFeedBackChat extends BusinessException {
+    public NotSavedFeedBackChat() {
+        super(ErrorCode.NOT_SAVED_FEEDBACKCHAT);
+    }
+}

--- a/src/main/java/com/witherview/configuration/RedisConfig.java
+++ b/src/main/java/com/witherview/configuration/RedisConfig.java
@@ -1,0 +1,61 @@
+package com.witherview.configuration;
+
+import com.witherview.chat.RedisSubscriber;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public ChannelTopic channelTopic() {
+        return new ChannelTopic("studyRoomChat");
+    }
+
+    // redis에 발행된 메시지 처리를 위한 리스너 설정
+    @Bean
+    public RedisMessageListenerContainer redisMessageListener(RedisConnectionFactory connectionFactory,
+                                                              MessageListenerAdapter listenerAdapter,
+                                                              ChannelTopic channelTopic) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listenerAdapter, channelTopic);
+        return container;
+    }
+
+    // 실제 메시지를 처리하는 subscriber 설정 추가
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RedisSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "sendMessage");
+    }
+
+    @Bean
+    public RedisTemplate<String,Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/witherview/configuration/StompHandler.java
+++ b/src/main/java/com/witherview/configuration/StompHandler.java
@@ -23,10 +23,13 @@ public class StompHandler implements ChannelInterceptor {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         // websocket 연결 후 subscribe 시 존재하는 방 구독하는지 체크
         if(StompCommand.SUBSCRIBE == accessor.getCommand()) {
+            String type = message.getHeaders().get("simpDestination").toString().split("/")[2];
             String room = message.getHeaders().get("simpDestination").toString().split("/")[3];
-            Long roomId = Long.parseLong(room);
+
+            Long id = Long.parseLong(room);
             try {
-                groupStudyService.findRoom(roomId);
+                if(type.equals("feedback")) groupStudyService.findStudyHistory(id);
+                else groupStudyService.findRoom(id);
             } catch (Exception e) {
                 throw new MessagingException(e.getMessage());
             }

--- a/src/main/java/com/witherview/configuration/StompHandler.java
+++ b/src/main/java/com/witherview/configuration/StompHandler.java
@@ -1,6 +1,7 @@
 package com.witherview.configuration;
 
-import com.witherview.groupPractice.GroupStudyService;
+import com.witherview.groupPractice.GroupStudy.GroupStudyService;
+import com.witherview.groupPractice.history.StudyHistoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class StompHandler implements ChannelInterceptor {
     private final GroupStudyService groupStudyService;
+    private final StudyHistoryService studyHistoryService;
 
     // websocket을 통해 들어온 요청이 처리 되기전 실행된다.
     @Override
@@ -28,7 +30,7 @@ public class StompHandler implements ChannelInterceptor {
 
             Long id = Long.parseLong(room);
             try {
-                if(type.equals("feedback")) groupStudyService.findStudyHistory(id);
+                if(type.equals("feedback")) studyHistoryService.findStudyHistory(id);
                 else groupStudyService.findRoom(id);
             } catch (Exception e) {
                 throw new MessagingException(e.getMessage());

--- a/src/main/java/com/witherview/configuration/WebSocketConfig.java
+++ b/src/main/java/com/witherview/configuration/WebSocketConfig.java
@@ -18,6 +18,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/socket")
                 .setAllowedOrigins("*")
                 .withSockJS();
+
+        registry.addEndpoint("/socket")
+                .setAllowedOrigins("*");
     }
 
     @Override

--- a/src/main/java/com/witherview/database/entity/FeedBackChat.java
+++ b/src/main/java/com/witherview/database/entity/FeedBackChat.java
@@ -5,14 +5,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
-@Entity @Getter
+@Entity
+@Getter
 @NoArgsConstructor
-@Table(name = "tbl_study_feedback")
-public class StudyFeedback extends CreatedBaseEntity {
-
-    @Id @GeneratedValue
+@Table(name = "tbl_feedback_chat")
+public class FeedBackChat {
+    @Id
+    @GeneratedValue
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -27,22 +30,19 @@ public class StudyFeedback extends CreatedBaseEntity {
     @JoinColumn(name = "study_history_id", nullable = false)
     private StudyHistory studyHistory;
 
-    @NotNull
-    private Byte score;
+    @NotBlank
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String message;
 
-    @NotNull
-    private Boolean passOrFail;
+    @NotNull @Column(nullable = false)
+    private LocalDateTime createdAt;
 
     @Builder
-    public StudyFeedback(User targetUser, User writtenUser,
-                         Byte score, Boolean passOrFail) {
-        this.targetUser = targetUser;
-        this.writtenUser = writtenUser;
-        this.score = score;
-        this.passOrFail = passOrFail;
-    }
-
-    protected void updateStudyHistory(StudyHistory studyHistory) {
+    public FeedBackChat(StudyHistory studyHistory, User writtenUser, User targetUser, String message, LocalDateTime createdAt) {
         this.studyHistory = studyHistory;
+        this.writtenUser = writtenUser;
+        this.targetUser = targetUser;
+        this.message = message;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/witherview/database/entity/StudyHistory.java
+++ b/src/main/java/com/witherview/database/entity/StudyHistory.java
@@ -1,0 +1,50 @@
+package com.witherview.database.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "tbl_group_study")
+public class StudyHistory extends CreatedBaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @NotNull
+    private Long studyRoom;
+
+    private String savedLocation;
+
+    @OneToMany(mappedBy = "studyHistory", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StudyFeedback> studyFeedbacks = new ArrayList<>();
+
+    @Builder
+    public StudyHistory(Long studyRoom) {
+        this.studyRoom = studyRoom;
+    }
+
+    protected void updateUser(User user) {
+        this.user = user;
+    }
+
+    public void updateSavedLocation(String savedLocation) {
+        this.savedLocation = savedLocation;
+    }
+
+    public void addStudyFeedBack(StudyFeedback studyFeedback) {
+        studyFeedback.updateStudyHistory(this);
+        this.studyFeedbacks.add(studyFeedback);
+    }
+}

--- a/src/main/java/com/witherview/database/entity/User.java
+++ b/src/main/java/com/witherview/database/entity/User.java
@@ -42,6 +42,9 @@ public class User {
     private Long selfPracticeCnt = 0L;
 
     @ColumnDefault("0")
+    private Long groupPracticeCnt = 0L;
+
+    @ColumnDefault("0")
     private Byte reliability = 70;
 
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -53,14 +56,11 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudyRoomParticipant> participatedStudyRooms = new ArrayList<>();
 
-    @OneToMany(mappedBy = "targetUser", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<StudyFeedback> studyFeedbacks = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StudyHistory> studyHistories = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SelfHistory> selfHistories = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<StudyVideo> studyVideos = new ArrayList<>();
 
     @Builder
     public User(String email, String password, String name,
@@ -78,6 +78,10 @@ public class User {
         this.selfPracticeCnt += 1;
     }
 
+    public void increaseGroupPracticeCnt() {
+        this.groupPracticeCnt += 1;
+    }
+
     public void addQuestionList(QuestionList questionList) {
         questionList.updateOwner(this);
         this.questionLists.add(questionList);
@@ -88,9 +92,9 @@ public class User {
         this.hostedStudyRooms.add(studyRoom);
     }
 
-    public void addStudyFeedback(StudyFeedback studyFeedback) {
-        studyFeedback.updateTargetUser(this);
-        this.studyFeedbacks.add(studyFeedback);
+    public void addStudyHistory(StudyHistory studyHistory) {
+        studyHistory.updateUser(this);
+        this.studyHistories.add(studyHistory);
     }
 
     public void addParticipatedRoom(StudyRoomParticipant participatedStudyRoom) {
@@ -100,10 +104,5 @@ public class User {
     public void addSelfHistory(SelfHistory selfHistory) {
         selfHistory.updateUser(this);
         this.selfHistories.add(selfHistory);
-    }
-
-    public void addStudyVideo(StudyVideo studyVideo) {
-        studyVideo.updateUser(this);
-        this.studyVideos.add(studyVideo);
     }
 }

--- a/src/main/java/com/witherview/database/repository/FeedBackChatRepository.java
+++ b/src/main/java/com/witherview/database/repository/FeedBackChatRepository.java
@@ -1,0 +1,11 @@
+package com.witherview.database.repository;
+
+import com.witherview.database.entity.FeedBackChat;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeedBackChatRepository extends JpaRepository<FeedBackChat, Long> {
+    List<FeedBackChat> findAllByStudyHistoryId(Pageable pageable, Long historyId);
+}

--- a/src/main/java/com/witherview/database/repository/StudyHistoryRepository.java
+++ b/src/main/java/com/witherview/database/repository/StudyHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.witherview.database.repository;
+
+import com.witherview.database.entity.StudyHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long> {
+}

--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -41,7 +41,10 @@ public enum ErrorCode {
     NOT_FOUND_CHECKLIST_TYPE(404, "SELF-CHECK002", "해당 체크리스트 타입이 없습니다."),
 
     // Video
-    NOT_SAVED_VIDEO(500, "VIDEO001", "비디오를 저장하는데 실패하였습니다.");
+    NOT_SAVED_VIDEO(500, "VIDEO001", "비디오를 저장하는데 실패하였습니다."),
+
+    // chat
+    NOT_SAVED_FEEDBACKCHAT(500, "CHAT001", "피드메세지 저장에 실패하였습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/witherview/exception/ErrorCode.java
+++ b/src/main/java/com/witherview/exception/ErrorCode.java
@@ -32,6 +32,10 @@ public enum ErrorCode {
     NOT_CREATED_FEEDBACK(404, "GROUP-PRACTICE006", "스터디룸에 참여하지 않은 사람에게 피드백을 줄 수 없습니다."),
     NOT_STUDYROOM_HOST(400, "GROUP-PRACTICE007", "해당 스터디룸의 호스트가 아닙니다."),
 
+    // group-History
+    NOT_FOUND_STUDYHISTORY(404, "GROUP-HISTORY001", "해당 스터디 연습 내역이 없습니다."),
+    NOT_OWNED_STUDYHISTORY(400, "GROUP-HISTORY002", "해당 스터디 연습 내역의 타겟 유저가 아닙니다."),
+
     // Self-History
     NOT_FOUND_HISTORY(404, "SELF-HISTORY001", "해당 혼자 연습 내역이 없습니다."),
     NOT_DELETED_FILE(500, "SELF_HISTORY002", "혼자 연습 영상 삭제에 실패하였습니다"),

--- a/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyController.java
@@ -1,4 +1,4 @@
-package com.witherview.groupPractice;
+package com.witherview.groupPractice.GroupStudy;
 
 import com.witherview.account.AccountSession;
 import com.witherview.database.entity.*;
@@ -139,32 +139,5 @@ public class GroupStudyController {
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
         StudyFeedback studyFeedback = groupStudyService.createFeedBack(accountSession.getId(), requestDto);
         return new ResponseEntity<>(modelMapper.map(studyFeedback, GroupStudyDTO.FeedBackResponseDTO.class), HttpStatus.CREATED);
-    }
-
-    @ApiOperation(value = "스터디 녹화 등록")
-    @PostMapping(path = "/video", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                  produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> uploadVideo(@RequestParam("videoFile") MultipartFile videoFile,
-                                         @RequestParam("studyHistoryId") Long studyHistoryId,
-                                         @ApiIgnore HttpSession session) {
-        AccountSession accountSession = (AccountSession) session.getAttribute("user");
-        StudyHistory studyHistory = groupStudyService.uploadVideo(videoFile, studyHistoryId, accountSession.getId());
-        return new ResponseEntity<>(modelMapper.map(studyHistory, GroupStudyDTO.HistoryResponseDTO.class), HttpStatus.OK);
-    }
-
-    @ApiOperation(value = "스터디 연습 내역 등록")
-    @PostMapping(path = "/history", consumes = MediaType.APPLICATION_JSON_VALUE,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> saveStudyHistory(@RequestBody @Valid GroupStudyDTO.StudyRequestDTO requestDto,
-                                              BindingResult result,
-                                              @ApiIgnore HttpSession session) {
-        if(result.hasErrors()) {
-            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
-            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-        }
-        AccountSession accountSession = (AccountSession) session.getAttribute("user");
-        StudyHistory studyHistory = groupStudyService.saveStudyHistory(requestDto.getId(), accountSession.getId());
-        return new ResponseEntity<>(modelMapper.map(studyHistory,
-                GroupStudyDTO.HistoryCreatedResponseDTO.class), HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyDTO.java
@@ -1,4 +1,4 @@
-package com.witherview.groupPractice;
+package com.witherview.groupPractice.GroupStudy;
 
 import com.witherview.database.entity.StudyRoom;
 import lombok.Builder;
@@ -119,24 +119,5 @@ public class GroupStudyDTO {
     @Getter @Setter
     public static class DeleteResponseDTO {
         private Long id;
-    }
-
-    @Getter @Setter
-    public static class HistoryCreatedResponseDTO {
-        private Long id;
-    }
-
-    @Getter @Setter
-    public static class HistoryResponseDTO {
-        private Long id;
-        private Long studyRoom;
-        private String savedLocation;
-        private LocalDateTime createdAt;
-    }
-
-    @Getter @Setter
-    public static class VideoSaveResponseDTO {
-        private Long id;
-        private String savedLocation;
     }
 }

--- a/src/main/java/com/witherview/groupPractice/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyController.java
@@ -1,10 +1,7 @@
 package com.witherview.groupPractice;
 
 import com.witherview.account.AccountSession;
-import com.witherview.database.entity.StudyFeedback;
-import com.witherview.database.entity.StudyRoom;
-import com.witherview.database.entity.StudyVideo;
-import com.witherview.database.entity.User;
+import com.witherview.database.entity.*;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
 import io.swagger.annotations.Api;
@@ -100,7 +97,7 @@ public class GroupStudyController {
 
     @ApiOperation(value="스터디방 참여")
     @PostMapping(path = "/room", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> joinRoom(@RequestBody @Valid GroupStudyDTO.StudyJoinDTO requestDto,
+    public ResponseEntity<?> joinRoom(@RequestBody @Valid GroupStudyDTO.StudyRequestDTO requestDto,
                                       BindingResult result,
                                       @ApiIgnore HttpSession session) {
         if(result.hasErrors()) {
@@ -148,10 +145,26 @@ public class GroupStudyController {
     @PostMapping(path = "/video", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
                                   produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> uploadVideo(@RequestParam("videoFile") MultipartFile videoFile,
-                                         @RequestParam("studyRoomId") Long studyRoomId,
+                                         @RequestParam("studyHistoryId") Long studyHistoryId,
                                          @ApiIgnore HttpSession session) {
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
-        StudyVideo studyVideo = groupStudyService.uploadVideo(videoFile, studyRoomId, accountSession.getId());
-        return new ResponseEntity<>(modelMapper.map(studyVideo, GroupStudyDTO.VideoSaveResponseDTO.class), HttpStatus.OK);
+        StudyHistory studyHistory = groupStudyService.uploadVideo(videoFile, studyHistoryId, accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(studyHistory, GroupStudyDTO.HistoryResponseDTO.class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "스터디 연습 내역 등록")
+    @PostMapping(path = "/history", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> saveStudyHistory(@RequestBody @Valid GroupStudyDTO.StudyRequestDTO requestDto,
+                                              BindingResult result,
+                                              @ApiIgnore HttpSession session) {
+        if(result.hasErrors()) {
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        }
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        StudyHistory studyHistory = groupStudyService.saveStudyHistory(requestDto.getId(), accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(studyHistory,
+                GroupStudyDTO.HistoryCreatedResponseDTO.class), HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyDTO.java
@@ -9,6 +9,7 @@ import org.hibernate.validator.constraints.Length;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class GroupStudyDTO {
@@ -62,8 +63,11 @@ public class GroupStudyDTO {
 
     @Getter @Setter @Builder
     public static class StudyFeedBackDTO {
-        @NotNull(message = "방 아이디는 반드시 입력해야 합니다.")
-        private Long id;
+        @NotNull(message = " 아이디는 반드시 입력해야 합니다.")
+        private Long studyRoomId;
+
+        @NotNull(message = "스터디 연습내역 아이디는 반드시 입력해야 합니다.")
+        private Long historyId;
 
         @NotNull(message = "타겟 유저아이디는 반드시 입력해야 합니다.")
         private Long targetUser;
@@ -76,7 +80,7 @@ public class GroupStudyDTO {
     }
 
     @Getter @Setter
-    public static class StudyJoinDTO {
+    public static class StudyRequestDTO {
         @NotNull(message = "방 아이디는 반드시 입력해야 합니다.")
         private Long id;
     }
@@ -99,7 +103,7 @@ public class GroupStudyDTO {
         private Long id;
         private String email;
         private String name;
-        private Long groupStudyCnt;
+        private Long groupPracticeCnt;
         private Byte reliability;
         private Boolean isHost;
     }
@@ -115,6 +119,19 @@ public class GroupStudyDTO {
     @Getter @Setter
     public static class DeleteResponseDTO {
         private Long id;
+    }
+
+    @Getter @Setter
+    public static class HistoryCreatedResponseDTO {
+        private Long id;
+    }
+
+    @Getter @Setter
+    public static class HistoryResponseDTO {
+        private Long id;
+        private Long studyRoom;
+        private String savedLocation;
+        private LocalDateTime createdAt;
     }
 
     @Getter @Setter

--- a/src/main/java/com/witherview/groupPractice/GroupStudyService.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudyService.java
@@ -109,6 +109,9 @@ public class GroupStudyService {
         if(findParticipant(requestDto.getStudyRoomId(), targetUser.getId()) == null) {
             throw new NotCreatedFeedback();
         }
+        if(studyHistory.getUser().getId() != targetUser.getId()) {
+            throw new NotOwnedStudyHistory();
+        }
         StudyFeedback studyFeedback = StudyFeedback.builder()
                                                     .targetUser(targetUser)
                                                     .writtenUser(writtenUser)

--- a/src/main/java/com/witherview/groupPractice/exception/NotFoundStudyHistory.java
+++ b/src/main/java/com/witherview/groupPractice/exception/NotFoundStudyHistory.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class NotFoundStudyHistory extends BusinessException {
+    public NotFoundStudyHistory() {
+        super(ErrorCode.NOT_FOUND_STUDYHISTORY);
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/exception/NotOwnedStudyHistory.java
+++ b/src/main/java/com/witherview/groupPractice/exception/NotOwnedStudyHistory.java
@@ -1,0 +1,10 @@
+package com.witherview.groupPractice.exception;
+
+import com.witherview.exception.BusinessException;
+import com.witherview.exception.ErrorCode;
+
+public class NotOwnedStudyHistory extends BusinessException {
+    public NotOwnedStudyHistory() {
+        super(ErrorCode.NOT_OWNED_STUDYHISTORY);
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/history/StudyHistoryController.java
+++ b/src/main/java/com/witherview/groupPractice/history/StudyHistoryController.java
@@ -1,0 +1,56 @@
+package com.witherview.groupPractice.history;
+
+import com.witherview.account.AccountSession;
+import com.witherview.database.entity.StudyHistory;
+import com.witherview.exception.ErrorCode;
+import com.witherview.exception.ErrorResponse;
+import com.witherview.groupPractice.GroupStudy.GroupStudyDTO;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+
+@Api(tags = "StudyHistory API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/group/history")
+public class StudyHistoryController {
+    private final ModelMapper modelMapper;
+    private final StudyHistoryService studyHistoryService;
+
+    @ApiOperation(value = "스터디 연습 내역 등록")
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> saveStudyHistory(@RequestBody @Valid GroupStudyDTO.StudyRequestDTO requestDto,
+                                              BindingResult result,
+                                              @ApiIgnore HttpSession session) {
+        if(result.hasErrors()) {
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        }
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        StudyHistory studyHistory = studyHistoryService.saveStudyHistory(requestDto.getId(), accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(studyHistory,
+                StudyHistoryDTO.HistoryCreatedResponseDTO.class), HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value = "스터디 녹화 등록")
+    @PostMapping(path = "/video", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> uploadVideo(@RequestParam("videoFile") MultipartFile videoFile,
+                                         @RequestParam("studyHistoryId") Long studyHistoryId,
+                                         @ApiIgnore HttpSession session) {
+        AccountSession accountSession = (AccountSession) session.getAttribute("user");
+        StudyHistory studyHistory = studyHistoryService.uploadVideo(videoFile, studyHistoryId, accountSession.getId());
+        return new ResponseEntity<>(modelMapper.map(studyHistory, StudyHistoryDTO.HistoryResponseDTO.class), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/history/StudyHistoryDTO.java
+++ b/src/main/java/com/witherview/groupPractice/history/StudyHistoryDTO.java
@@ -1,0 +1,28 @@
+package com.witherview.groupPractice.history;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+public class StudyHistoryDTO {
+    @Getter
+    @Setter
+    public static class HistoryCreatedResponseDTO {
+        private Long id;
+    }
+
+    @Getter @Setter
+    public static class HistoryResponseDTO {
+        private Long id;
+        private Long studyRoom;
+        private String savedLocation;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter @Setter
+    public static class VideoSaveResponseDTO {
+        private Long id;
+        private String savedLocation;
+    }
+}

--- a/src/main/java/com/witherview/groupPractice/history/StudyHistoryService.java
+++ b/src/main/java/com/witherview/groupPractice/history/StudyHistoryService.java
@@ -1,0 +1,64 @@
+package com.witherview.groupPractice.history;
+
+import com.witherview.database.entity.StudyHistory;
+import com.witherview.database.entity.StudyRoom;
+import com.witherview.database.entity.StudyRoomParticipant;
+import com.witherview.database.entity.User;
+import com.witherview.database.repository.*;
+import com.witherview.groupPractice.exception.NotFoundStudyHistory;
+import com.witherview.groupPractice.exception.NotFoundStudyRoom;
+import com.witherview.groupPractice.exception.NotJoinedStudyRoom;
+import com.witherview.groupPractice.exception.NotOwnedStudyHistory;
+import com.witherview.selfPractice.exception.NotFoundUser;
+import com.witherview.video.VideoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class StudyHistoryService {
+
+    private final UserRepository userRepository;
+    private final StudyRoomRepository studyRoomRepository;
+    private final StudyHistoryRepository studyHistoryRepository;
+    private final StudyRoomParticipantRepository studyRoomParticipantRepository;
+    private final VideoService videoService;
+
+    @Transactional
+    public StudyHistory uploadVideo(MultipartFile videoFile, Long historyId, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
+        StudyHistory studyHistory = findStudyHistory(historyId);
+
+        if (!user.getId().equals(studyHistory.getUser().getId())) {
+            throw new NotOwnedStudyHistory();
+        }
+        String savedLocation = videoService.upload(videoFile,
+                user.getEmail() + "/group/" + historyId);
+        studyHistory.updateSavedLocation(savedLocation);
+        return studyHistory;
+    }
+
+    @Transactional
+    public StudyHistory saveStudyHistory(Long studyRoomId, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUser::new);
+        studyRoomRepository.findById(studyRoomId).orElseThrow(NotFoundStudyRoom::new);
+        StudyRoomParticipant studyRoomParticipant = studyRoomParticipantRepository
+                .findByStudyRoomIdAndUserId(studyRoomId, userId);
+
+        if (studyRoomParticipant == null) {
+            throw new NotJoinedStudyRoom();
+        }
+
+        StudyHistory studyHistory = StudyHistory.builder().studyRoom(studyRoomId).build();
+        user.addStudyHistory(studyHistory);
+        user.increaseGroupPracticeCnt();
+        return studyHistoryRepository.save(studyHistory);
+    }
+
+    public StudyHistory findStudyHistory(Long id) {
+        return studyHistoryRepository.findById(id).orElseThrow(NotFoundStudyHistory::new);
+    }
+}

--- a/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
@@ -4,6 +4,7 @@ import com.witherview.account.AccountSession;
 import com.witherview.database.entity.StudyRoom;
 import com.witherview.database.entity.StudyRoomParticipant;
 import com.witherview.database.entity.User;
+import com.witherview.groupPractice.GroupStudy.GroupStudyDTO;
 import com.witherview.groupPractice.exception.NotFoundStudyRoom;
 import com.witherview.selfPractice.exception.NotFoundUser;
 import org.junit.jupiter.api.Test;
@@ -335,7 +336,7 @@ public class GroupStudyApiTest extends GroupStudySupporter {
         MockMultipartFile file = new MockMultipartFile("video",
                 "video.webm", "video/webm", "test webm".getBytes());
 
-        ResultActions resultActions = mockMvc.perform(multipart("/api/group/video")
+        ResultActions resultActions = mockMvc.perform(multipart("/api/group/history/video")
                 .file("videoFile", file.getBytes())
                 .param("studyHistoryId", "0")
                 .session(mockHttpSession))
@@ -353,7 +354,7 @@ public class GroupStudyApiTest extends GroupStudySupporter {
         MockMultipartFile file = new MockMultipartFile("video",
                 "video.webm", "video/webm", "test webm".getBytes());
 
-        ResultActions resultActions = mockMvc.perform(multipart("/api/group/video")
+        ResultActions resultActions = mockMvc.perform(multipart("/api/group/history/video")
                 .file("videoFile", file.getBytes())
                 .param("studyHistoryId", studyHistoryId1.toString())
                 .session(mockHttpSession))

--- a/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
@@ -1,11 +1,9 @@
 package com.witherview.groupPractice;
 
 import com.witherview.account.AccountSession;
-import com.witherview.database.entity.StudyFeedback;
-import com.witherview.database.entity.StudyRoom;
-import com.witherview.database.entity.StudyRoomParticipant;
-import com.witherview.database.entity.User;
+import com.witherview.database.entity.*;
 import com.witherview.database.repository.StudyFeedbackRepository;
+import com.witherview.database.repository.StudyHistoryRepository;
 import com.witherview.database.repository.StudyRoomRepository;
 import com.witherview.database.repository.UserRepository;
 import com.witherview.support.MockMvcSupporter;
@@ -48,6 +46,8 @@ public class GroupStudySupporter extends MockMvcSupporter {
     Long userId2 = (long)2;
     Long userId3 = (long)3;
     Long roomId = (long) 4;
+    Long studyHistoryId1 = (long) 1;
+    Long studyHistoryId2 = (long) 2;
     @Autowired
     UserRepository userRepository;
 
@@ -56,6 +56,9 @@ public class GroupStudySupporter extends MockMvcSupporter {
 
     @Autowired
     StudyFeedbackRepository studyFeedbackRepository;
+
+    @Autowired
+    StudyHistoryRepository studyHistoryRepository;
 
     @Autowired
     PasswordEncoder passwordEncoder;
@@ -100,25 +103,25 @@ public class GroupStudySupporter extends MockMvcSupporter {
         studyRoom.addParticipants(studyRoomParticipant2);
         user3.addParticipatedRoom(studyRoomParticipant2);
 
+        // 스터디 연습 내역 등록
+        StudyHistory studyHistory1 = StudyHistory.builder().studyRoom(roomId).build();
+        user1.addStudyHistory(studyHistory1);
+        user1.increaseGroupPracticeCnt();
+        studyHistoryId1 = studyHistoryRepository.save(studyHistory1).getId();
+
+        StudyHistory studyHistory2 = StudyHistory.builder().studyRoom(roomId).build();
+        user2.addStudyHistory(studyHistory2);
+        studyHistoryId2 = studyHistoryRepository.save(studyHistory2).getId();
+
         // 피드백 등록
         StudyFeedback studyFeedback1 = StudyFeedback.builder()
-                .studyRoom(roomId)
-                .writtenUser(user1)
-                .score(score)
-                .passOrFail(passOrFail)
-                .build();
-
-        user3.addStudyFeedback(studyFeedback1);
-        studyFeedbackRepository.save(studyFeedback1);
-
-        StudyFeedback studyFeedback2 = StudyFeedback.builder()
-                .studyRoom(roomId)
+                .targetUser(user1)
                 .writtenUser(user3)
                 .score(score)
                 .passOrFail(passOrFail)
                 .build();
 
-        user1.addStudyFeedback(studyFeedback2);
-        studyFeedbackRepository.save(studyFeedback2);
+        studyHistory1.addStudyFeedBack(studyFeedback1);
+        studyFeedbackRepository.save(studyFeedback1);
     }
 }


### PR DESCRIPTION
## 채팅 부분
- redis pub/sub 을 통해 채팅 서버 여러대일 경우 메세지 동기화 되도록 함
- 피드백 메세지 들어올 경우 1차적으로 redis에 캐싱처리 해놓은 후 최종적으로 저장 api 요청 시 mysql 에 저장되도록 처리 

## 그룹스터디 
- 그룹스터디 구조 변경
  - 현재 그룹 스터디 관련 api 들이 너무 하나의 파일에 몰려? 있다고 판단하여
  스터디 관련 / 스터디 내역(히스토리) 관련으로 폴더 나눔
- 스터디 내역 관련 플로우 변경
  - 혼자 연습하기 내역과 같은 방식으로 스터디 연습내역 등록 api 요청하여 히스토리 id 받아온 다음 → 해당 히스토리에 연습 영상 저장 및 피드백 채팅 내역 저장 되도록 함