### PR TITLE
스터디룸 생성 시 방 타입 지정하도록 하기(#47)

### DIFF
--- a/src/main/java/com/witherview/database/entity/StudyRoom.java
+++ b/src/main/java/com/witherview/database/entity/StudyRoom.java
@@ -43,6 +43,9 @@ public class StudyRoom {
     @Column(nullable = false)
     private Integer maxUserCnt;
 
+    @ColumnDefault("'자유_기타'")
+    private String category;
+
     @ColumnDefault("'무관'")
     private String industry;
 
@@ -63,10 +66,11 @@ public class StudyRoom {
 
     @Builder
     public StudyRoom(String title, String description,
-                     String industry, String job,
+                     String category, String industry, String job,
                      LocalDate date, LocalTime time) {
         this.title = title;
         this.description = description;
+        this.category = category;
         this.industry = industry;
         this.job = job;
         this.date = date;

--- a/src/main/java/com/witherview/database/repository/StudyRoomRepository.java
+++ b/src/main/java/com/witherview/database/repository/StudyRoomRepository.java
@@ -1,7 +1,11 @@
 package com.witherview.database.repository;
 
 import com.witherview.database.entity.StudyRoom;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
+    List<StudyRoom> findAllByCategory(Pageable pageable, String category);
 }

--- a/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyController.java
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpSession;
@@ -108,6 +107,15 @@ public class GroupStudyController {
         AccountSession accountSession = (AccountSession) session.getAttribute("user");
         StudyRoom studyRoom = groupStudyService.joinRoom(requestDto.getId(), accountSession.getId());
         return new ResponseEntity<>(modelMapper.map(studyRoom, GroupStudyDTO.ResponseDTO.class), HttpStatus.OK);
+    }
+
+    @ApiOperation(value="특정 카테고리 별 스터디방 조회")
+    @GetMapping("/room")
+    public ResponseEntity<?> findCategoryRooms(@ApiParam(value = "조회할 방 카테고리") @RequestParam String category,
+                                               @ApiParam(value = "조회할 page (디폴트 값 = 0)")
+                                               @RequestParam(value = "page", required = false) Integer current) {
+        List<StudyRoom> lists = groupStudyService.findCategoryRooms(category, current);
+        return new ResponseEntity<>(modelMapper.map(lists, GroupStudyDTO.ResponseDTO[].class), HttpStatus.OK);
     }
 
     @ApiOperation(value="해당 스터디방 참여자 조회")

--- a/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyDTO.java
@@ -9,7 +9,6 @@ import org.hibernate.validator.constraints.Length;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class GroupStudyDTO {
@@ -25,6 +24,7 @@ public class GroupStudyDTO {
         @Length(max = 100, message = "방 설명은 100자 이하여야 합니다.")
         private String description;
 
+        private String category;
         private String industry;
         private String job;
 
@@ -35,6 +35,7 @@ public class GroupStudyDTO {
             return StudyRoom.builder()
                     .title(title)
                     .description(description)
+                    .category(category)
                     .industry(industry)
                     .job(job)
                     .date(date)
@@ -54,6 +55,7 @@ public class GroupStudyDTO {
         @NotBlank(message = "방 설명은 반드시 입력해야 합니다.")
         private String description;
 
+        private String category;
         private String industry;
         private String job;
 
@@ -90,6 +92,7 @@ public class GroupStudyDTO {
         private Long id;
         private String title;
         private String description;
+        private String category;
         private String industry;
         private String job;
         private LocalDate date;

--- a/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyService.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyService.java
@@ -161,4 +161,11 @@ public class GroupStudyService {
 
         return studyRoomRepository.findAll(pageRequest).getContent();
     }
+
+    public List<StudyRoom> findCategoryRooms(String category, Integer current) {
+        int page = current == null ? 0 : current;
+        Pageable pageRequest = PageRequest.of(page, pageSize, Sort.by("date", "time").ascending());
+
+        return studyRoomRepository.findAllByCategory(pageRequest, category);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,10 +19,14 @@ task:
 
 spring:
   datasource:
-    username: guest
+    username: root
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/witherview?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+
+  redis:
+    host: localhost
+    port: 6379
 
   devtools:
     livereload:
@@ -57,7 +61,7 @@ logging:
 spring:
   profiles: test
   datasource:
-    username: guest
+    username: root
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/witherview_test?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
@@ -71,7 +75,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudyApiTest.java
@@ -26,6 +26,7 @@ public class GroupStudyApiTest extends GroupStudySupporter {
         GroupStudyDTO.StudyCreateDTO dto = GroupStudyDTO.StudyCreateDTO.builder()
                 .title(title2)
                 .description(description2)
+                .category(category1)
                 .industry(industry1)
                 .job(job1)
                 .date(date2)
@@ -164,6 +165,21 @@ public class GroupStudyApiTest extends GroupStudySupporter {
         resultActions.andExpect(jsonPath("$[1].groupPracticeCnt").value(0));
         resultActions.andExpect(jsonPath("$[1].reliability").value(70));
         resultActions.andExpect(jsonPath("$[1].isHost").value(false));
+    }
+
+    @Test
+    public void 스터디룸_카테고리별_조회성공() throws Exception {
+        ResultActions resultActions = mockMvc.perform(get("/api/group/room?category=" + "이공계_사기업")
+                .session(mockHttpSession))
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(jsonPath("$[0].title").value(title1));
+        resultActions.andExpect(jsonPath("$[0].description").value(description1));
+        resultActions.andExpect(jsonPath("$[0].category").value(category1));
+        resultActions.andExpect(jsonPath("$[0].industry").value(industry1));
+        resultActions.andExpect(jsonPath("$[0].job").value(job1));
+        resultActions.andExpect(jsonPath("$[0].date").value(date1.toString()));
+        resultActions.andExpect(jsonPath("$[0].time").value(time1.toString()));
     }
 
     @Test

--- a/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
+++ b/src/test/java/com/witherview/groupPractice/GroupStudySupporter.java
@@ -30,6 +30,7 @@ public class GroupStudySupporter extends MockMvcSupporter {
     final String title1 = "네이버 빅데이터 플랫폼 스터디 모집합니다.";
     final String description1 =  "코딩테스트 합격자만 신청바랍니다!!!!";
     final String industry1 = "it서비스";
+    final String category1 = "이공계_사기업";
     final String job1 = "개발자";
     final LocalDate date1 = LocalDate.parse("2020-12-03");
     final LocalTime time1 = LocalTime.parse("15:00:01");
@@ -83,7 +84,7 @@ public class GroupStudySupporter extends MockMvcSupporter {
         mockHttpSession.setAttribute("user", accountSession);
 
         // 스터디룸생성
-        StudyRoom studyRoom = new StudyRoom(title1, description1, industry1, job1, date1, time1);
+        StudyRoom studyRoom = new StudyRoom(title1, description1, category1, industry1, job1, date1, time1);
         user1.addHostedRoom(studyRoom);
         roomId = studyRoomRepository.save(studyRoom).getId();
 


### PR DESCRIPTION
### 추가한 사항
- 스터디룸 카테고리 별 조회하는 api 구현

### 수정한 사항
- 스터디룸 생성 시 방 타입 ex) 이공계_사기업, 이공계_공기업 등 지정하도록 StudyRoom 엔티티 변경